### PR TITLE
Fix codegen inlining of record union

### DIFF
--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Inline.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Inline.purs
@@ -7,14 +7,14 @@ import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Dodo as Dodo
-import PureScript.Backend.Optimizer.Codegen.EcmaScript.Common (esUpdateLeft, esUpdateRight)
+import PureScript.Backend.Optimizer.Codegen.EcmaScript.Common (EsStatement(..), esUpdateLeft, esUpdateRight)
 import PureScript.Backend.Optimizer.Codegen.Tco (TcoExpr(..))
 import PureScript.Backend.Optimizer.CoreFn (Ident, Literal(..), Qualified)
 import PureScript.Backend.Optimizer.Semantics.Foreign (qualified)
 import PureScript.Backend.Optimizer.Syntax (BackendSyntax(..))
 
 type EsInline a = Tuple (Qualified Ident) (EsInlineCall a)
-type EsInlineCall a = (TcoExpr -> Dodo.Doc a) -> Qualified Ident -> Array TcoExpr -> Maybe (Dodo.Doc a)
+type EsInlineCall a = (TcoExpr -> Dodo.Doc a) -> Qualified Ident -> Array TcoExpr -> Maybe (Tuple (Dodo.Doc a) (EsStatement (Dodo.Doc a)))
 type EsInlineMap a = Map (Qualified Ident) (EsInlineCall a)
 
 esInlineMap :: forall a. EsInlineMap a
@@ -26,9 +26,11 @@ record_unsafe_union_unsafeUnionFn :: forall a. EsInline a
 record_unsafe_union_unsafeUnionFn = Tuple (qualified "Record.Unsafe.Union" "unsafeUnionFn") go
   where
   go codegenExpr _ = case _ of
-    [ lhs, TcoExpr _ (Lit (LitRecord props)) ] ->
-      Just $ esUpdateRight (map codegenExpr <$> props) (codegenExpr lhs)
-    [ TcoExpr _ (Lit (LitRecord props)), rhs ] ->
-      Just $ esUpdateLeft (codegenExpr rhs) (map codegenExpr <$> props)
+    [ lhs, TcoExpr _ (Lit (LitRecord props)) ] -> do
+      let doc = esUpdateRight (map codegenExpr <$> props) (codegenExpr lhs)
+      Just $ Tuple doc (ReturnObject doc)
+    [ TcoExpr _ (Lit (LitRecord props)), rhs ] -> do
+      let doc = esUpdateLeft (codegenExpr rhs) (map codegenExpr <$> props)
+      Just $ Tuple doc (ReturnObject doc)
     _ ->
       Nothing

--- a/backend-es/test/snapshots-out/Snapshot.RecordUnion01.js
+++ b/backend-es/test/snapshots-out/Snapshot.RecordUnion01.js
@@ -1,0 +1,4 @@
+import * as $runtime from "../runtime.js";
+import * as Record$dUnsafe$dUnion from "../Record.Unsafe.Union/index.js";
+const test = a => ({...a, foo: 42});
+export {test};

--- a/backend-es/test/snapshots/Snapshot.RecordUnion01.purs
+++ b/backend-es/test/snapshots/Snapshot.RecordUnion01.purs
@@ -1,0 +1,6 @@
+module Snapshot.RecordUnion01 where
+
+import Record (union)
+
+test :: forall r. { | r } -> { foo :: Int | r }
+test a = union { foo: 42 } a


### PR DESCRIPTION
Previously this could generate a lambda without the parens around the body, which is syntactically invalid.