### PR TITLE
Fix hygiene for top-level bindings.

### DIFF
--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript.purs
@@ -150,10 +150,18 @@ renameTopLevel ident env = fromMaybe (Tuple ident RefStrict) $ Map.lookup (Codeg
 esCodegenModule :: forall a. CodegenOptions -> BackendImplementations -> BackendModule -> Dodo.Doc a
 esCodegenModule options implementations mod = do
   let
+    topLevelBound :: Map Ident Int
+    topLevelBound = foldl
+      ( \bs { bindings } ->
+          foldr (flip Map.insert 1 <<< fst) bs bindings
+      )
+      (foldr (flip Map.insert 1) Map.empty mod.foreign)
+      mod.bindings
+
     codegenEnv :: CodegenEnv
     codegenEnv =
       { currentModule: mod.name
-      , bound: Map.empty
+      , bound: topLevelBound
       , names: Map.empty
       , emitPure: true
       , options

--- a/backend-es/test/snapshots-out/Snapshot.TopLevelHygiene01.js
+++ b/backend-es/test/snapshots-out/Snapshot.TopLevelHygiene01.js
@@ -1,0 +1,4 @@
+// @inline export test1 always
+import * as $runtime from "../runtime.js";
+const test1 = wat => a => wat(a);
+export {test1};

--- a/backend-es/test/snapshots-out/Snapshow.TopLevelHygiene02.js
+++ b/backend-es/test/snapshots-out/Snapshow.TopLevelHygiene02.js
@@ -1,0 +1,4 @@
+import * as $runtime from "../runtime.js";
+const wat = 42;
+const test2 = wat$1 => a => wat$1(a);
+export {test2, wat};

--- a/backend-es/test/snapshots/Snapshot.TopLevelHygiene01.purs
+++ b/backend-es/test/snapshots/Snapshot.TopLevelHygiene01.purs
@@ -1,0 +1,6 @@
+-- @inline export test1 always
+module Snapshot.TopLevelHygiene01 where
+
+-- This is imported by TopLevelHygiene02, which has a top-level wat binding.
+test1 :: forall a b. (a -> b) -> a -> b
+test1 = \wat a -> wat a

--- a/backend-es/test/snapshots/Snapshow.TopLevelHygiene02.purs
+++ b/backend-es/test/snapshots/Snapshow.TopLevelHygiene02.purs
@@ -1,0 +1,9 @@
+module Snapshow.TopLevelHygiene02 where
+
+import Snapshot.TopLevelHygiene01 (test1)
+
+wat :: Int
+wat = 42
+
+test2 :: forall a b. (a -> b) -> a -> b
+test2 = test1

--- a/src/PureScript/Backend/Optimizer/Debug.js
+++ b/src/PureScript/Backend/Optimizer/Debug.js
@@ -4,3 +4,8 @@ export const time_ = name => k => {
   console.timeEnd(name);
   return res;
 };
+
+export const traceImpl = a => k => {
+  console.dir(a, { depth: null });
+  return k();
+};

--- a/src/PureScript/Backend/Optimizer/Debug.purs
+++ b/src/PureScript/Backend/Optimizer/Debug.purs
@@ -2,15 +2,17 @@ module PureScript.Backend.Optimizer.Debug where
 
 import Prelude
 
-import Debug (class DebugWarning, trace)
+import Debug (class DebugWarning)
 
 traceWhen :: forall a b. DebugWarning => Boolean -> a -> b -> b
-traceWhen bool a b = if bool then trace a \_ -> b else b
+traceWhen bool a b = if bool then traceImpl a \_ -> b else b
 
 spyWhen :: forall a. DebugWarning => Boolean -> a -> a
 spyWhen bool a = traceWhen bool a a
 
 foreign import time_ :: forall a. String -> (Unit -> a) -> a
+
+foreign import traceImpl :: forall a b. a -> (Unit -> b) -> b
 
 time :: forall a. DebugWarning => String -> (Unit -> a) -> a
 time = time_


### PR DESCRIPTION
Fixes #26

This indeed was a straightforward issue with hygiene, but it was masked by the compiler doing it's own unique renaming. To exhibit the bug you have to inline _across_ modules, such that the inlined expression introduces a binding that shadows a top-level binding.

The actual bug is just that I wasn't putting top-level bindings in the `bound` map.