### PR TITLE
Fix analysis and heuristic for derefs.

### DIFF
--- a/backend-es/test/snapshots-out/Snapshot.CaptureDerefRegression01.js
+++ b/backend-es/test/snapshots-out/Snapshot.CaptureDerefRegression01.js
@@ -1,0 +1,12 @@
+const $Box = _1 => ({tag: "Box", _1});
+const Box = value0 => $Box(value0);
+const test3 = v => {
+  const $0 = v._1;
+  return $Box(b => $0 + b | 0);
+};
+const test2 = v => {
+  const $0 = v._1;
+  return b => $0 + b | 0;
+};
+const test1 = v => b => v._1 + b | 0;
+export {$Box, Box, test1, test2, test3};

--- a/backend-es/test/snapshots/Snapshot.CaptureDerefRegression01.purs
+++ b/backend-es/test/snapshots/Snapshot.CaptureDerefRegression01.purs
@@ -1,0 +1,17 @@
+module Snapshot.CaptureDerefRegression01 where
+
+import Prelude
+
+import Data.Identity (Identity(..))
+import Data.Tuple (Tuple(..))
+
+data Box a = Box a
+
+test1 :: Tuple Int Int -> Int -> Int
+test1 (Tuple a _) b = a + b
+
+test2 :: Tuple Int Int -> Identity (Int -> Int)
+test2 (Tuple a _) = Identity \b -> a + b
+
+test3 :: Tuple Int Int -> Box (Int -> Int)
+test3 (Tuple a _) = Box \b -> a + b

--- a/src/PureScript/Backend/Optimizer/Analysis.purs
+++ b/src/PureScript/Backend/Optimizer/Analysis.purs
@@ -341,7 +341,7 @@ analyze externAnalysis expr = case expr of
       Just (Accessor _ _) ->
         analysis
       Just (Local _ lvl) ->
-        accessed lvl analysis
+        accessed lvl $ complex Deref analysis
       Just (Var qi) -> do
         let BackendAnalysis { args } = externAnalysis (Tuple qi (Just acc))
         withArgs args $ complex Trivial analysis

--- a/src/PureScript/Backend/Optimizer/Semantics.purs
+++ b/src/PureScript/Backend/Optimizer/Semantics.purs
@@ -1475,9 +1475,11 @@ shouldInlineLet level a b = do
   case Map.lookup level s2.usages of
     Nothing ->
       true
-    Just (Usage { captured, total }) ->
+    Just (Usage { captured, total, call }) ->
       (s1.complexity == Trivial)
-        || (captured == CaptureNone && (total == 1 || (s1.complexity <= Deref && s1.size < 5)))
+        || (captured == CaptureNone && total == 1)
+        || (captured <= CaptureBranch && s1.complexity <= Deref && s1.size < 5)
+        || (s1.complexity == Deref && call == total)
         || (s1.complexity == KnownSize && total == 1)
         || (isAbs a && (total == 1 || Map.isEmpty s1.usages || s1.size < 16))
         || (isKnownEffect a && total == 1)


### PR DESCRIPTION
Captured derefs shouldn't be indiscriminately inlined, but this was happening due to a missing analysis. This isn't unsound or anything, as it's what the main compiler does, but it can lead to space leaks when an object is captured by a closure, but only certain fields are accessed.

For now, I've kept the inlining if the field is known to be a function, or rather always called with arguments, since it results in much better codegen for typeclass code.