### PR TITLE
Add type/constructor info to GetOffset/GetCtorField

### DIFF
--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
@@ -278,7 +278,7 @@ codegenExpr env@(CodegenEnv { currentModule, inlineApp }) tcoExpr@(TcoExpr _ exp
         codegenEffectBlock env tcoExpr
   Accessor a (GetProp prop) ->
     build $ EsAccess (codegenExpr env a) prop
-  Accessor a (GetCtorField _ _ ix) ->
+  Accessor a (GetCtorField _ _ _ _ _ ix) ->
     build $ EsAccess (codegenExpr env a) ("_" <> show (ix + 1))
   Accessor a (GetIndex ix) ->
     build $ EsIndex (codegenExpr env a) (build (EsInt ix))

--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
@@ -278,7 +278,7 @@ codegenExpr env@(CodegenEnv { currentModule, inlineApp }) tcoExpr@(TcoExpr _ exp
         codegenEffectBlock env tcoExpr
   Accessor a (GetProp prop) ->
     build $ EsAccess (codegenExpr env a) prop
-  Accessor a (GetCtorField ix) ->
+  Accessor a (GetCtorField _ _ ix) ->
     build $ EsAccess (codegenExpr env a) ("_" <> show (ix + 1))
   Accessor a (GetIndex ix) ->
     build $ EsIndex (codegenExpr env a) (build (EsInt ix))

--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
@@ -278,7 +278,7 @@ codegenExpr env@(CodegenEnv { currentModule, inlineApp }) tcoExpr@(TcoExpr _ exp
         codegenEffectBlock env tcoExpr
   Accessor a (GetProp prop) ->
     build $ EsAccess (codegenExpr env a) prop
-  Accessor a (GetOffset ix) ->
+  Accessor a (GetCtorField ix) ->
     build $ EsAccess (codegenExpr env a) ("_" <> show (ix + 1))
   Accessor a (GetIndex ix) ->
     build $ EsIndex (codegenExpr env a) (build (EsInt ix))

--- a/backend-es/test/Main.purs
+++ b/backend-es/test/Main.purs
@@ -77,7 +77,7 @@ main = do
 runSnapshotTests :: TestArgs -> Aff Unit
 runSnapshotTests { accept, filter } = do
   liftEffect $ Process.chdir $ Path.concat [ "backend-es", "test", "snapshots" ]
-  spawnFromParent "spago" [ "build", "-u", "-g corefn" ]
+  spawnFromParent "spago" [ "build", "-u", "-g", "corefn" ]
   snapshotDir <- liftEffect Process.cwd
   snapshotPaths <- expandGlobsCwd [ "Snapshot.*.purs" ]
   outputRef <- liftEffect $ Ref.new Map.empty

--- a/backend-es/test/Main.purs
+++ b/backend-es/test/Main.purs
@@ -77,7 +77,7 @@ main = do
 runSnapshotTests :: TestArgs -> Aff Unit
 runSnapshotTests { accept, filter } = do
   liftEffect $ Process.chdir $ Path.concat [ "backend-es", "test", "snapshots" ]
-  spawnFromParent "spago" [ "build", "-u", "-g", "corefn" ]
+  spawnFromParent "spago" [ "build", "-u", "-g corefn" ]
   snapshotDir <- liftEffect Process.cwd
   snapshotPaths <- expandGlobsCwd [ "Snapshot.*.purs" ]
   outputRef <- liftEffect $ Ref.new Map.empty

--- a/src/PureScript/Backend/Optimizer/Convert.purs
+++ b/src/PureScript/Backend/Optimizer/Convert.purs
@@ -70,7 +70,7 @@ import Data.Traversable (class Foldable, Accum, foldr, for, mapAccumL, mapAccumR
 import Data.Tuple (Tuple(..), fst, snd)
 import Partial.Unsafe (unsafeCrashWith, unsafePartial)
 import PureScript.Backend.Optimizer.Analysis (BackendAnalysis)
-import PureScript.Backend.Optimizer.CoreFn (Ann(..), Bind(..), Binder(..), Binding(..), CaseAlternative(..), CaseGuard(..), Comment, ConstructorType(..), Expr(..), Guard(..), Ident(..), Literal(..), Meta(..), Module(..), ModuleName(..), ProperName(..), Qualified(..), ReExport, findProp, propKey, propValue, qualifiedModuleName, unQualified)
+import PureScript.Backend.Optimizer.CoreFn (Ann(..), Bind(..), Binder(..), Binding(..), CaseAlternative(..), CaseGuard(..), Comment, ConstructorType(..), Expr(..), Guard(..), Ident(..), Literal(..), Meta(..), Module(..), ModuleName(..), ProperName, Qualified(..), ReExport, findProp, propKey, propValue, qualifiedModuleName, unQualified)
 import PureScript.Backend.Optimizer.Directives (DirectiveHeaderResult, parseDirectiveHeader)
 import PureScript.Backend.Optimizer.Semantics (BackendExpr(..), BackendSemantics, Ctx, DataTypeMeta, Env(..), EvalRef(..), ExternImpl(..), ExternSpine, InlineAccessor(..), InlineDirective(..), InlineDirectiveMap, NeutralExpr(..), build, evalExternFromImpl, freeze, optimize)
 import PureScript.Backend.Optimizer.Semantics.Foreign (ForeignEval)
@@ -622,13 +622,8 @@ binderToPattern dataTypes implementations = case _ of
   lookupCtorFields ty ctor =
     case importedCtorFields <|> localCtorFields of
       Just fields -> fields
-      Nothing -> unsafeCrashWith $ "Unable to get fields for type [" <> printQP ty <> "]'s constructor [" <> printQI ctor <> "]"
+      Nothing -> unsafeCrashWith "Invariant broken: could not determine pattern matched constructor's fields during conversion."
     where
-    printQ :: forall a. (a -> String) -> Qualified a -> String
-    printQ printS (Qualified mbMod s) = maybe (printS s) (\(ModuleName mn) -> mn <> "." <> printS s) mbMod
-    printQP = printQ (\(ProperName s) -> s)
-    printQI = printQ (\(Ident i) -> i)
-
     importedCtorFields = case Map.lookup ctor implementations of
       Just (Tuple _ (ExternCtor _ _ _ _ fields)) -> Just fields
       _ -> Nothing

--- a/src/PureScript/Backend/Optimizer/Convert.purs
+++ b/src/PureScript/Backend/Optimizer/Convert.purs
@@ -576,13 +576,13 @@ binderToPattern = case _ of
       ctorPattern
         (PatProduct tyName ctorName)
         args
-        (\idx _ -> GetOffset idx)
+        (\idx _ -> GetCtorField idx)
         identity
     Just (IsConstructor SumType _) ->
       ctorPattern
         (PatSum tyName ctorName)
         args
-        (\idx _ -> GetOffset idx)
+        (\idx _ -> GetCtorField idx)
         identity
     _ ->
       unsafeCrashWith "binderToPattern - invalid meta"

--- a/src/PureScript/Backend/Optimizer/Convert.purs
+++ b/src/PureScript/Backend/Optimizer/Convert.purs
@@ -576,13 +576,13 @@ binderToPattern = case _ of
       ctorPattern
         (PatProduct tyName ctorName)
         args
-        (\idx _ -> GetCtorField idx)
+        (\idx _ -> GetCtorField tyName ctorName idx)
         identity
     Just (IsConstructor SumType _) ->
       ctorPattern
         (PatSum tyName ctorName)
         args
-        (\idx _ -> GetCtorField idx)
+        (\idx _ -> GetCtorField tyName ctorName idx)
         identity
     _ ->
       unsafeCrashWith "binderToPattern - invalid meta"

--- a/src/PureScript/Backend/Optimizer/Convert.purs
+++ b/src/PureScript/Backend/Optimizer/Convert.purs
@@ -444,7 +444,7 @@ toBackendExpr = case _ of
           makeLet Nothing (toBackendExpr expr) \tmp ->
             next (Array.snoc idents tmp)
       )
-      ( \idents -> do
+      ( \idents ->
           toInitialCaseRows idents alts \caseRows ->
             buildCaseTreeFromRows caseRows
       )

--- a/src/PureScript/Backend/Optimizer/Semantics.purs
+++ b/src/PureScript/Backend/Optimizer/Semantics.purs
@@ -518,7 +518,7 @@ evalAccessor initEnv initLhs accessor =
       , Just sem <- Array.index values n ->
           sem
     NeutData _ _ _ _ fields
-      | GetCtorField _ _ n <- accessor
+      | GetCtorField _ _ _ _ _ n <- accessor
       , Just (Tuple _ sem) <- Array.index fields n ->
           sem
     NeutFail err ->

--- a/src/PureScript/Backend/Optimizer/Semantics.purs
+++ b/src/PureScript/Backend/Optimizer/Semantics.purs
@@ -518,7 +518,7 @@ evalAccessor initEnv initLhs accessor =
       , Just sem <- Array.index values n ->
           sem
     NeutData _ _ _ _ fields
-      | GetOffset n <- accessor
+      | GetCtorField n <- accessor
       , Just (Tuple _ sem) <- Array.index fields n ->
           sem
     NeutFail err ->

--- a/src/PureScript/Backend/Optimizer/Semantics.purs
+++ b/src/PureScript/Backend/Optimizer/Semantics.purs
@@ -518,7 +518,7 @@ evalAccessor initEnv initLhs accessor =
       , Just sem <- Array.index values n ->
           sem
     NeutData _ _ _ _ fields
-      | GetCtorField n <- accessor
+      | GetCtorField _ _ n <- accessor
       , Just (Tuple _ sem) <- Array.index fields n ->
           sem
     NeutFail err ->

--- a/src/PureScript/Backend/Optimizer/Syntax.purs
+++ b/src/PureScript/Backend/Optimizer/Syntax.purs
@@ -51,7 +51,7 @@ sndPair (Pair _ a) = a
 data BackendAccessor
   = GetProp String
   | GetIndex Int
-  | GetCtorField Int
+  | GetCtorField (Qualified ProperName) (Qualified Ident) Int
 
 derive instance Eq BackendAccessor
 derive instance Ord BackendAccessor

--- a/src/PureScript/Backend/Optimizer/Syntax.purs
+++ b/src/PureScript/Backend/Optimizer/Syntax.purs
@@ -51,7 +51,7 @@ sndPair (Pair _ a) = a
 data BackendAccessor
   = GetProp String
   | GetIndex Int
-  | GetOffset Int
+  | GetCtorField Int
 
 derive instance Eq BackendAccessor
 derive instance Ord BackendAccessor

--- a/src/PureScript/Backend/Optimizer/Syntax.purs
+++ b/src/PureScript/Backend/Optimizer/Syntax.purs
@@ -51,7 +51,7 @@ sndPair (Pair _ a) = a
 data BackendAccessor
   = GetProp String
   | GetIndex Int
-  | GetCtorField (Qualified ProperName) (Qualified Ident) Int
+  | GetCtorField (Qualified Ident) ConstructorType ProperName Ident String Int
 
 derive instance Eq BackendAccessor
 derive instance Ord BackendAccessor


### PR DESCRIPTION
- Rename `GetOffset` to `GetCtorField` for clarity
- Add the following pieces of information to `GetCtorField`
    - qualified constructor name
    - constructor type
    - unqualified type name
    - unqualified constructor name
    - constructor's field's name