### PR TITLE
Add snapshot for exports

### DIFF
--- a/backend-es/test/snapshots-out/Snapshot.Exports.js
+++ b/backend-es/test/snapshots-out/Snapshot.Exports.js
@@ -1,0 +1,8 @@
+const $DataTypeAndCtor = _1 => ({tag: "DataTypeAndCtor", _1});
+const NewtypeTypeAndCtor = x => x;
+const DataTypeAndCtor = value0 => $DataTypeAndCtor(value0);
+const useNewtypeTypeOnly = v => v;
+const useDataTypeOnlyCtorNameChange = v => v._1;
+const useDataTypeOnly = v => v._1;
+const classExportedMember = dict => dict.classExportedMember;
+export {$DataTypeAndCtor, DataTypeAndCtor, NewtypeTypeAndCtor, classExportedMember, useDataTypeOnly, useDataTypeOnlyCtorNameChange, useNewtypeTypeOnly};

--- a/backend-es/test/snapshots/Snapshot.Exports.purs
+++ b/backend-es/test/snapshots/Snapshot.Exports.purs
@@ -1,0 +1,43 @@
+module Snapshot.Exports
+  ( DataTypeOnly
+  , useDataTypeOnly
+  , DataTypeOnlyCtorNameChange
+  , useDataTypeOnlyCtorNameChange
+  , DataTypeAndCtor(..)
+  , NewtypeTypeOnly
+  , useNewtypeTypeOnly
+  , NewtypeTypeAndCtor(..)
+  , TypeExported
+  , class ClassExported
+  , classExportedMember
+  ) where
+
+data DataTypeOnly = DataTypeOnly Int
+
+useDataTypeOnly :: DataTypeOnly -> Int
+useDataTypeOnly (DataTypeOnly i) = i
+
+data DataTypeOnlyCtorNameChange = DataTypeOnlyCtor Int
+
+useDataTypeOnlyCtorNameChange :: DataTypeOnlyCtorNameChange -> Int
+useDataTypeOnlyCtorNameChange (DataTypeOnlyCtor i) = i
+
+data DataTypeAndCtor = DataTypeAndCtor Int
+
+newtype NewtypeTypeOnly = NewtypeTypeOnly Int
+
+useNewtypeTypeOnly :: NewtypeTypeOnly -> Int
+useNewtypeTypeOnly (NewtypeTypeOnly i) = i
+
+newtype NewtypeTypeAndCtor = NewtypeTypeAndCtor Int
+
+type TypeNoExport = Int
+
+type TypeExported = Int
+
+class ClassExported a where
+  classExportedMember :: a -> String
+
+class ClassNoExport a where
+  classNoExportMember :: a -> String
+


### PR DESCRIPTION
We came across this issue: https://github.com/purescm/purescm/pull/85#discussion_r1151114499

I presume the problem lays here (https://github.com/aristanetworks/purescript-backend-optimizer/blob/main/src/PureScript/Backend/Optimizer/Convert.purs#L159-L191) in that `isBindingUsed` doesn't always return true for constructor definitions.

The present PR just shows that types that do not export their constructor (e.g. the constructors for `DataTypeOnly`, `DataTypeOnlyCtorNameChange`, and `NewtypeTypeOnly`) will not be included in the resulting `BackendModule`'s `bindings`. I'm not sure about how the type classes should be handled yet, but that may also be an issue.