### PR TITLE
Remove Maybe from fallback in Branch

### DIFF
--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
@@ -455,8 +455,7 @@ codegenBlockBranches mode env total bs def = case total of
   Root Total | mode.return == Discard ->
     foldr (\p -> pure <<< build <<< uncurry EsIfElse (go p)) (codegenBlockStatements mode env def) bs
   _ ->
-    NonEmptyArray.toArray (build <<< flip (uncurry EsIfElse) [] <<< go <$> bs)
-      <> (codegenBlockStatements mode env) def
+    NonEmptyArray.toArray (build <<< flip (uncurry EsIfElse) [] <<< go <$> bs) <> codegenBlockStatements mode env def
   where
   go :: Pair TcoExpr -> Tuple EsExpr (Array EsExpr)
   go (Pair a b@(TcoExpr (TcoAnalysis s) b')) = case b' of

--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
@@ -451,11 +451,10 @@ codegenBlockReturn mode env tcoExpr
           pure $ build $ EsReturn $ Just $ codegenExpr env tcoExpr
 
 codegenBlockBranches :: BlockMode -> CodegenEnv -> Total -> NonEmptyArray (Pair TcoExpr) -> TcoExpr -> Array EsExpr
-codegenBlockBranches mode env total bs def = case total, def of
-  Root Total, def'
-    | mode.return == Discard ->
-        foldr (\p -> pure <<< build <<< uncurry EsIfElse (go p)) (codegenBlockStatements mode env def') bs
-  _, _ ->
+codegenBlockBranches mode env total bs def = case total of
+  Root Total | mode.return == Discard ->
+    foldr (\p -> pure <<< build <<< uncurry EsIfElse (go p)) (codegenBlockStatements mode env def) bs
+  _ ->
     NonEmptyArray.toArray (build <<< flip (uncurry EsIfElse) [] <<< go <$> bs)
       <> (codegenBlockStatements mode env) def
   where

--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
@@ -450,14 +450,14 @@ codegenBlockReturn mode env tcoExpr
         Return ->
           pure $ build $ EsReturn $ Just $ codegenExpr env tcoExpr
 
-codegenBlockBranches :: BlockMode -> CodegenEnv -> Total -> NonEmptyArray (Pair TcoExpr) -> Maybe TcoExpr -> Array EsExpr
+codegenBlockBranches :: BlockMode -> CodegenEnv -> Total -> NonEmptyArray (Pair TcoExpr) -> TcoExpr -> Array EsExpr
 codegenBlockBranches mode env total bs def = case total, def of
-  Root Total, Just def'
+  Root Total, def'
     | mode.return == Discard ->
         foldr (\p -> pure <<< build <<< uncurry EsIfElse (go p)) (codegenBlockStatements mode env def') bs
   _, _ ->
     NonEmptyArray.toArray (build <<< flip (uncurry EsIfElse) [] <<< go <$> bs)
-      <> maybe [] (codegenBlockStatements mode env) def
+      <> (codegenBlockStatements mode env) def
   where
   go :: Pair TcoExpr -> Tuple EsExpr (Array EsExpr)
   go (Pair a b@(TcoExpr (TcoAnalysis s) b')) = case b' of

--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
@@ -387,7 +387,7 @@ codegenBlockStatements = go []
             TcoExpr _ (Branch bs def) -> do
               let lines = codegenBlockBranches (mode { return = Discard }) env bs def -- TODO
               go (acc <> lines) mode env body
-            _ -> do            
+            _ -> do
               let line = codegenBindEffect env eff
               go (Array.snoc acc line) mode env body
     EffectBind ident lvl eff body

--- a/src/PureScript/Backend/Optimizer/Analysis.purs
+++ b/src/PureScript/Backend/Optimizer/Analysis.purs
@@ -314,7 +314,7 @@ analyze externAnalysis expr = case expr of
       analysisOf a
         <> capture CaptureBranch (analysisOf b)
         <> capture CaptureBranch (foldMap (foldMap analysisOf) (NonEmptyArray.tail bs))
-        <> capture CaptureBranch (foldMap analysisOf def)
+        <> capture CaptureBranch (analysisOf def)
   Fail _ ->
     complex NonTrivial
       $ analyzeDefault expr

--- a/src/PureScript/Backend/Optimizer/Codegen/Tco.purs
+++ b/src/PureScript/Backend/Optimizer/Codegen/Tco.purs
@@ -11,7 +11,7 @@ import Data.List (List)
 import Data.List as List
 import Data.Map (Map)
 import Data.Map as Map
-import Data.Maybe (Maybe(..), isJust, maybe)
+import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (class Newtype)
 import Data.Set (Set)
 import Data.Set as Set
@@ -295,12 +295,9 @@ analyze env (NeutralExpr expr) = case expr of
     TcoExpr analysis $ PrimEffect (EffectRefWrite ref' val')
   Branch branches def -> do
     let branches' = map (\(Pair a b) -> Pair (overTcoAnalysis tcoNoTailCalls (analyze env a)) (analyze env b)) branches
-    let def' = analyze env <$> def
-    let analysis@(TcoAnalysis { total }) = foldMap (foldMap tcoAnalysisOf) branches' <> foldMap tcoAnalysisOf def'
-    if isJust def then
-      TcoExpr (tcoTotal (Root total) analysis) $ Branch branches' def'
-    else
-      TcoExpr (tcoTotal Partial analysis) $ Branch branches' def'
+    let def' = analyze env def
+    let analysis@(TcoAnalysis { total }) = foldMap (foldMap tcoAnalysisOf) branches' <> tcoAnalysisOf def'
+    TcoExpr (tcoTotal (Root total) analysis) $ Branch branches' def'
   Let ident level binding body -> do
     let binding' = analyze env binding
     let body' = analyze env body

--- a/src/PureScript/Backend/Optimizer/Codegen/Tco.purs
+++ b/src/PureScript/Backend/Optimizer/Codegen/Tco.purs
@@ -100,22 +100,10 @@ instance Monoid TcoUsage where
     , readWrite: 0
     }
 
-data Total = Total | Partial | Root Total
-
-instance Semigroup Total where
-  append = case _, _ of
-    Partial, _ -> Partial
-    _, Partial -> Partial
-    _, _ -> Total
-
-instance Monoid Total where
-  mempty = Total
-
 newtype TcoAnalysis = TcoAnalysis
   { usages :: Map TcoRef TcoUsage
   , tailCalls :: Map TcoRef Int
   , role :: TcoRole
-  , total :: Total
   }
 
 derive instance Newtype TcoAnalysis _
@@ -125,7 +113,6 @@ instance Semigroup TcoAnalysis where
     { usages: Map.unionWith append a.usages b.usages
     , tailCalls: Map.unionWith add a.tailCalls b.tailCalls
     , role: noTcoRole
-    , total: a.total <> b.total
     }
 
 instance Monoid TcoAnalysis where
@@ -133,7 +120,6 @@ instance Monoid TcoAnalysis where
     { usages: Map.empty
     , tailCalls: Map.empty
     , role: noTcoRole
-    , total: mempty
     }
 
 type TcoRole =
@@ -180,11 +166,6 @@ tcoNoTailCalls :: TcoAnalysis -> TcoAnalysis
 tcoNoTailCalls (TcoAnalysis s) = TcoAnalysis s
   { tailCalls = Map.empty
   , role = s.role { joins = [] }
-  }
-
-tcoTotal :: Total -> TcoAnalysis -> TcoAnalysis
-tcoTotal total (TcoAnalysis s) = TcoAnalysis s
-  { total = total
   }
 
 withTcoRole :: TcoRole -> TcoAnalysis -> TcoAnalysis
@@ -261,43 +242,43 @@ syntacticArity = case _ of
 analyze :: TcoEnv -> NeutralExpr -> TcoExpr
 analyze env (NeutralExpr expr) = case expr of
   Var ident ->
-    TcoExpr (tcoTotal Total $ tcoCall (TcoTopLevel ident) 0 mempty) $ Var ident
+    TcoExpr (tcoCall (TcoTopLevel ident) 0 mempty) $ Var ident
   Local ident level ->
-    TcoExpr (tcoTotal Total $ tcoCall (TcoLocal ident level) 0 mempty) $ Local ident level
+    TcoExpr (tcoCall (TcoLocal ident level) 0 mempty) $ Local ident level
   App hd@(NeutralExpr (Local ident level)) tl -> do
     let hd' = analyze env hd
     let tl' = overTcoAnalysis tcoNoTailCalls <<< analyze env <$> tl
-    let analysis2 = tcoTotal Total $ tcoCall (TcoLocal ident level) (NonEmptyArray.length tl') (foldMap tcoAnalysisOf tl')
+    let analysis2 = tcoCall (TcoLocal ident level) (NonEmptyArray.length tl') (foldMap tcoAnalysisOf tl')
     TcoExpr analysis2 $ App hd' tl'
   App hd@(NeutralExpr (Var ident)) tl -> do
     let hd' = analyze env hd
     let tl' = overTcoAnalysis tcoNoTailCalls <<< analyze env <$> tl
-    let analysis2 = tcoTotal Total $ tcoCall (TcoTopLevel ident) (NonEmptyArray.length tl') (foldMap tcoAnalysisOf tl')
+    let analysis2 = tcoCall (TcoTopLevel ident) (NonEmptyArray.length tl') (foldMap tcoAnalysisOf tl')
     TcoExpr analysis2 $ App hd' tl'
   UncurriedApp hd@(NeutralExpr (Local ident level)) tl -> do
     let hd' = analyze env hd
     let tl' = overTcoAnalysis tcoNoTailCalls <<< analyze env <$> tl
-    let analysis2 = tcoTotal Total $ tcoCall (TcoLocal ident level) (Array.length tl') (foldMap tcoAnalysisOf tl')
+    let analysis2 = tcoCall (TcoLocal ident level) (Array.length tl') (foldMap tcoAnalysisOf tl')
     TcoExpr analysis2 $ UncurriedApp hd' tl'
   UncurriedApp hd@(NeutralExpr (Var ident)) tl -> do
     let hd' = analyze env hd
     let tl' = overTcoAnalysis tcoNoTailCalls <<< analyze env <$> tl
-    let analysis2 = tcoTotal Total $ tcoCall (TcoTopLevel ident) (Array.length tl') (foldMap tcoAnalysisOf tl')
+    let analysis2 = tcoCall (TcoTopLevel ident) (Array.length tl') (foldMap tcoAnalysisOf tl')
     TcoExpr analysis2 $ UncurriedApp hd' tl'
   PrimEffect (EffectRefRead ref@(NeutralExpr (Local ident level))) -> do
     let ref' = analyze env ref
-    let analysis = tcoTotal Total $ tcoRefEffect (TcoLocal ident level) mempty
+    let analysis = tcoRefEffect (TcoLocal ident level) mempty
     TcoExpr analysis $ PrimEffect (EffectRefRead ref')
   PrimEffect (EffectRefWrite ref@(NeutralExpr (Local ident level)) val) -> do
     let ref' = analyze env ref
     let val' = analyze env val
-    let analysis = tcoTotal Total $ tcoRefEffect (TcoLocal ident level) $ tcoAnalysisOf val'
+    let analysis = tcoRefEffect (TcoLocal ident level) $ tcoAnalysisOf val'
     TcoExpr analysis $ PrimEffect (EffectRefWrite ref' val')
   Branch branches def -> do
     let branches' = map (\(Pair a b) -> Pair (overTcoAnalysis tcoNoTailCalls (analyze env a)) (analyze env b)) branches
     let def' = analyze env def
-    let analysis@(TcoAnalysis { total }) = foldMap (foldMap tcoAnalysisOf) branches' <> tcoAnalysisOf def'
-    TcoExpr (tcoTotal (Root total) analysis) $ Branch branches' def'
+    let analysis = foldMap (foldMap tcoAnalysisOf) branches' <> tcoAnalysisOf def'
+    TcoExpr analysis $ Branch branches' def'
   Let ident level binding body -> do
     let binding' = analyze env binding
     let body' = analyze env body
@@ -306,10 +287,10 @@ analyze env (NeutralExpr expr) = case expr of
     let role = { isLoop: false, joins: foldMap (tcoRoleJoins env (tcoAnalysisOf body') <<< pure) refBinding }
     case refBinding of
       Just rb | hasTcoRole role -> do
-        let analysis = tcoTotal Total $ rb.analysis <> tcoAnalysisOf body'
+        let analysis = rb.analysis <> tcoAnalysisOf body'
         TcoExpr (withTcoRole role analysis) expr'
       _ -> do
-        let analysis = tcoTotal Total $ tcoNoTailCalls (tcoAnalysisOf binding') <> tcoAnalysisOf body'
+        let analysis = tcoNoTailCalls (tcoAnalysisOf binding') <> tcoAnalysisOf body'
         TcoExpr analysis expr'
   LetRec level bindings body -> do
     let group = localTcoEnvGroup level bindings
@@ -321,11 +302,11 @@ analyze env (NeutralExpr expr) = case expr of
     let isLoop = maybe false tcoRoleIsLoop refBindings
     let role = { isLoop, joins: foldMap (tcoRoleJoins env (tcoAnalysisOf body')) refBindings }
     if hasTcoRole role then do
-      let analysis = tcoTotal Total $ foldMap (foldMap _.analysis) refBindings <> tcoAnalysisOf body'
+      let analysis = foldMap (foldMap _.analysis) refBindings <> tcoAnalysisOf body'
       TcoExpr (withTcoRole role analysis) expr'
     else do
-      let analysis = tcoTotal Total $ tcoNoTailCalls (foldMap (foldMap tcoAnalysisOf) bindings') <> tcoAnalysisOf body'
+      let analysis = tcoNoTailCalls (foldMap (foldMap tcoAnalysisOf) bindings') <> tcoAnalysisOf body'
       TcoExpr analysis expr'
   _ -> do
     let expr' = analyze env <$> expr
-    TcoExpr (tcoTotal Total $ tcoNoTailCalls (foldMap tcoAnalysisOf expr')) expr'
+    TcoExpr (tcoNoTailCalls (foldMap tcoAnalysisOf expr')) expr'

--- a/src/PureScript/Backend/Optimizer/Convert.purs
+++ b/src/PureScript/Backend/Optimizer/Convert.purs
@@ -233,7 +233,7 @@ toBackendTopLevelBindingGroup env = case _ of
 
 toTopLevelBackendBinding :: Array (Qualified Ident) -> ConvertEnv -> Binding Ann -> Accum ConvertEnv (Tuple Ident (WithDeps NeutralExpr))
 toTopLevelBackendBinding group env (Binding _ ident cfn) = do
-  let evalEnv = Env { currentModule: env.currentModule, evalExtern: makeExternEval env, locals: [], directives: env.directives, branchTry: Nothing }
+  let evalEnv = Env { currentModule: env.currentModule, evalExtern: makeExternEval env, locals: [], directives: env.directives }
   let backendExpr = toBackendExpr cfn env
   let Tuple impl expr' = toExternImpl env group (optimize (getCtx env) evalEnv (Qualified (Just env.currentModule) ident) env.rewriteLimit backendExpr)
   { accum: env

--- a/src/PureScript/Backend/Optimizer/Convert.purs
+++ b/src/PureScript/Backend/Optimizer/Convert.purs
@@ -706,7 +706,7 @@ buildCaseLeaf row0 tailRows = do
             pairs <- for gs \(Tuple pred bodyFn) ->
               Pair <$> toBackendExpr pred <*> callFn bodyFn args
             fallback <- buildCaseTreeFromRows tailRows
-            buildM $ Branch pairs (Just fallback)
+            buildM $ Branch pairs fallback
         )
         orderedArgs
         []
@@ -940,7 +940,7 @@ makeGuard
   -> ConvertM BackendExpr
   -> ConvertM BackendExpr
 makeGuard lvl g inner def =
-  make $ Branch (NonEmptyArray.singleton (Pair (make (g (make (Local Nothing lvl)))) inner)) (Just def)
+  make $ Branch (NonEmptyArray.singleton (Pair (make (g (make (Local Nothing lvl)))) inner)) def
 
 makeUncurriedAbs
   :: Array Ident

--- a/src/PureScript/Backend/Optimizer/Semantics.purs
+++ b/src/PureScript/Backend/Optimizer/Semantics.purs
@@ -1224,8 +1224,8 @@ buildBranchCond ctx (Pair a b) c = case b of
         c
     | ExprSyntax _ (Lit (LitBoolean false)) <- c ->
         a
-    | x@(ExprSyntax _ x') <- c, isBooleanTail x' ->
-        build ctx (PrimOp (Op2 OpBooleanOr a x))
+    | ExprSyntax _ x <- c, isBooleanTail x ->
+        build ctx (PrimOp (Op2 OpBooleanOr a c))
   ExprSyntax _ (Lit (LitBoolean false))
     | ExprSyntax _ (Lit (LitBoolean false)) <- c ->
         c

--- a/src/PureScript/Backend/Optimizer/Syntax.purs
+++ b/src/PureScript/Backend/Optimizer/Syntax.purs
@@ -28,7 +28,7 @@ data BackendSyntax a
   | EffectBind (Maybe Ident) Level a a
   | EffectPure a
   | EffectDefer a
-  | Branch (NonEmptyArray (Pair a)) (Maybe a)
+  | Branch (NonEmptyArray (Pair a)) a
   | PrimOp (BackendOperator a)
   | PrimEffect (BackendEffect a)
   | PrimUndefined
@@ -144,7 +144,7 @@ instance Foldable BackendSyntax where
     EffectBind _ _ b c -> f b <> f c
     EffectPure a -> f a
     EffectDefer a -> f a
-    Branch as b -> foldMap (foldMap f) as <> foldMap f b
+    Branch as b -> foldMap (foldMap f) as <> f b
     PrimOp a -> foldMap f a
     PrimEffect a -> foldMap f a
     PrimUndefined -> mempty
@@ -199,7 +199,7 @@ instance Traversable BackendSyntax where
     EffectDefer a ->
       EffectDefer <$> f a
     Branch as b ->
-      Branch <$> traverse (traverse f) as <*> traverse f b
+      Branch <$> traverse (traverse f) as <*> f b
     PrimOp a ->
       PrimOp <$> traverse f a
     PrimEffect a ->


### PR DESCRIPTION
This changes the signature of Branch from:
```hs
Branch (NonEmptyArray (Pair a)) (Maybe a)
```

to:
```hs
Branch (NonEmptyArray (Pair a)) a
```

This PR is mostly just involves whacking type errors but _I think_ fixing them intuitively is enough for correctness.