### PR TITLE
Fix optimize loop guard

### DIFF
--- a/backend-es/test/snapshots-out/Snapshot.InlineNever.js
+++ b/backend-es/test/snapshots-out/Snapshot.InlineNever.js
@@ -1,0 +1,4 @@
+// @inline Snapshot.InlineNever.foo never
+const foo = "foo";
+const test = foo;
+export {foo, test};

--- a/backend-es/test/snapshots/Snapshot.InlineNever.purs
+++ b/backend-es/test/snapshots/Snapshot.InlineNever.purs
@@ -1,0 +1,8 @@
+-- @inline Snapshot.InlineNever.foo never
+module Snapshot.InlineNever where
+
+foo :: String
+foo = "foo"
+
+test :: String
+test = foo

--- a/src/PureScript/Backend/Optimizer/Semantics.purs
+++ b/src/PureScript/Backend/Optimizer/Semantics.purs
@@ -1509,11 +1509,11 @@ optimize ctx env (Qualified mn (Ident id)) initN = go initN
         unsafeCrashWith $ name <> ": Possible infinite optimization loop."
     | otherwise = do
         let expr2 = quote ctx (eval env expr1)
-        case expr2 of
-          ExprSyntax (BackendAnalysis { rewrite }) _ | not rewrite ->
-            expr2
-          _ ->
-            go (n - 1) expr2
+        let BackendAnalysis { rewrite } = analysisOf expr2
+        if rewrite then
+          go (n - 1) expr2
+        else
+          expr2
 
 freeze :: BackendExpr -> Tuple BackendAnalysis NeutralExpr
 freeze init = Tuple (analysisOf init) (go init)


### PR DESCRIPTION
The loop guard was pattern matching on BackendExpr only, but the InlineNever case was emitting BackendRewrite RewriteStop.

Fixes #49