### PR TITLE
Bump arrays dependency, update semantics

### DIFF
--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Foreign.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Foreign.purs
@@ -4,14 +4,15 @@ import Prelude
 
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Enum (fromEnum)
+import Data.Lazy as Lazy
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import PureScript.Backend.Optimizer.CoreFn (Ident, Literal(..), Qualified)
-import PureScript.Backend.Optimizer.Semantics (BackendSemantics(..), ExternSpine(..), evalApp, evalPrimOp, makeLet)
+import PureScript.Backend.Optimizer.Semantics (BackendSemantics(..), ExternSpine(..), SemConditional(..), evalApp, evalPrimOp, liftInt, makeLet)
 import PureScript.Backend.Optimizer.Semantics.Foreign (ForeignEval, ForeignSemantics, qualified)
-import PureScript.Backend.Optimizer.Syntax (BackendOperator(..), BackendOperator2(..))
+import PureScript.Backend.Optimizer.Syntax (BackendOperator(..), BackendOperator1(..), BackendOperator2(..), BackendOperatorOrd(..))
 import PureScript.Backend.Optimizer.Utils (foldr1Array)
 
 esForeignSemantics :: Map (Qualified Ident) ForeignEval
@@ -19,6 +20,7 @@ esForeignSemantics = Map.fromFoldable
   [ control_monad_st_internal_for
   , control_monad_st_internal_foreach
   , control_monad_st_internal_while
+  , data_array_indexImpl
   , data_array_st_push
   , data_array_st_unshift
   , data_array_st_unsafeFreeze
@@ -43,6 +45,29 @@ esForeignSemantics = Map.fromFoldable
   , foreign_object_st_poke
   , foreign_object_st_unsafe_unsafeFreeze
   ]
+
+data_array_indexImpl :: ForeignSemantics
+data_array_indexImpl = Tuple (qualified "Data.Array" "indexImpl") go
+  where
+  go env _ = case _ of
+    [ ExternUncurriedApp [ just, nothing, arr, ix ] ] ->
+      Just $ makeLet Nothing arr \arr' ->
+        makeLet Nothing ix \ix' ->
+          SemBranch
+            ( NonEmptyArray.singleton $ SemConditional
+                ( Lazy.defer \_ ->
+                    evalPrimOp env $ Op2 OpBooleanAnd
+                      (evalPrimOp env (Op2 (OpIntOrd OpGte) ix' (liftInt 0)))
+                      (evalPrimOp env (Op2 (OpIntOrd OpLt) ix' (evalPrimOp env (Op1 OpArrayLength arr'))))
+                )
+                ( Lazy.defer \_ ->
+                    evalApp env just
+                      [ evalPrimOp env (Op2 OpArrayIndex arr' ix') ]
+                )
+            )
+            (pure nothing)
+    _ ->
+      Nothing
 
 data_array_st_push :: ForeignSemantics
 data_array_st_push = Tuple (qualified "Data.Array.ST" "push") $ arraySTAll (qualified "Data.Array.ST" "pushAll")

--- a/backend-es/test/snapshots-out/Snapshot.CaseLeafTco.js
+++ b/backend-es/test/snapshots-out/Snapshot.CaseLeafTco.js
@@ -5,58 +5,51 @@ const test1 = test1$a0$copy => test1$a1$copy => {
   let test1$a0 = test1$a0$copy, test1$a1 = test1$a1$copy, test1$c = true, test1$r;
   while (test1$c) {
     const b = test1$a0, arr = test1$a1;
-    const v = Data$dArray.index(arr)(arr.length - 1 | 0);
-    const v1 = Data$dArray.index(arr)(0);
-    const $0 = (x, y) => {
-      if (b) {
-        test1$c = false;
-        test1$r = [];
-        return;
-      }
-      test1$a0 = b;
-      test1$a1 = Data$dSemigroup.concatArray([y, x, 3, y, 5, 6, 7, 8, 9, 10, x, 12, 13, 14, 15, 16, 17])(arr);
-    };
-    if (v.tag === "Just") {
-      if (v._1 === 2) {
-        if (v1.tag === "Just") {
-          if (v1._1 === 1) {
+    const v = Data$dArray.last(arr);
+    if (0 < arr.length) {
+      const $0 = (x, y) => {
+        if (b) {
+          test1$c = false;
+          test1$r = [];
+          return;
+        }
+        test1$a0 = b;
+        test1$a1 = Data$dSemigroup.concatArray([y, x, 3, y, 5, 6, 7, 8, 9, 10, x, 12, 13, 14, 15, 16, 17])(arr);
+      };
+      if (v.tag === "Just") {
+        if (v._1 === 2) {
+          if (arr[0] === 1) {
             test1$c = false;
             test1$r = arr;
             continue;
           }
-          $0(v1._1, v._1);
+          $0(arr[0], v._1);
           continue;
         }
-        if (v1.tag === "Nothing") {
-          test1$c = false;
-          test1$r = Data$dSemigroup.concatArray(arr)([v._1]);
-          continue;
-        }
-        $runtime.fail();
-      }
-      if (v1.tag === "Nothing") {
-        test1$c = false;
-        test1$r = Data$dSemigroup.concatArray(arr)([v._1]);
+        $0(arr[0], v._1);
         continue;
       }
-      if (v1.tag === "Just") {
-        $0(v1._1, v._1);
+      if (v.tag === "Nothing") {
+        test1$c = false;
+        test1$r = Data$dSemigroup.concatArray(arr)([arr[0]]);
         continue;
       }
       $runtime.fail();
     }
+    if (v.tag === "Just") {
+      if (v._1 === 2) {
+        test1$c = false;
+        test1$r = Data$dSemigroup.concatArray(arr)([v._1]);
+        continue;
+      }
+      test1$c = false;
+      test1$r = Data$dSemigroup.concatArray(arr)([v._1]);
+      continue;
+    }
     if (v.tag === "Nothing") {
-      if (v1.tag === "Nothing") {
-        test1$c = false;
-        test1$r = arr;
-        continue;
-      }
-      if (v1.tag === "Just") {
-        test1$c = false;
-        test1$r = Data$dSemigroup.concatArray(arr)([v1._1]);
-        continue;
-      }
-      $runtime.fail();
+      test1$c = false;
+      test1$r = arr;
+      continue;
     }
     $runtime.fail();
   }

--- a/backend-es/test/snapshots-out/Snapshot.InlineArrayIndex.js
+++ b/backend-es/test/snapshots-out/Snapshot.InlineArrayIndex.js
@@ -1,0 +1,37 @@
+// @inline export testArrayIndex never
+import * as $runtime from "../runtime.js";
+import * as Assert from "../Assert/index.js";
+import * as Data$dMaybe from "../Data.Maybe/index.js";
+import * as Data$dShow from "../Data.Show/index.js";
+const assertEqual = /* #__PURE__ */ Assert.assertEqual({
+  eq: x => y => {
+    if (x.tag === "Nothing") { return y.tag === "Nothing"; }
+    if (x.tag === "Just") {
+      if (y.tag === "Just") { return x._1 === y._1; }
+      return false;
+    }
+    return false;
+  }
+})({
+  show: v => {
+    if (v.tag === "Just") { return "(Just " + Data$dShow.showIntImpl(v._1) + ")"; }
+    if (v.tag === "Nothing") { return "Nothing"; }
+    $runtime.fail();
+  }
+});
+const testArrayIndex = arr => ix => {
+  if (ix >= 0 && ix < arr.length) { return Data$dMaybe.$Maybe("Just", arr[ix]); }
+  return Data$dMaybe.Nothing;
+};
+const main = /* #__PURE__ */ (() => {
+  const array = [1, 2, 3];
+  const $0 = assertEqual("index -1")({expected: Data$dMaybe.Nothing, actual: testArrayIndex(array)(-1)});
+  return () => {
+    $0();
+    assertEqual("index 0")({expected: Data$dMaybe.$Maybe("Just", 1), actual: testArrayIndex(array)(0)})();
+    assertEqual("index 1")({expected: Data$dMaybe.$Maybe("Just", 2), actual: testArrayIndex(array)(1)})();
+    assertEqual("index 2")({expected: Data$dMaybe.$Maybe("Just", 3), actual: testArrayIndex(array)(2)})();
+    return assertEqual("index 3")({expected: Data$dMaybe.Nothing, actual: testArrayIndex(array)(3)})();
+  };
+})();
+export {assertEqual, main, testArrayIndex};

--- a/backend-es/test/snapshots-out/Snapshot.Tco05.js
+++ b/backend-es/test/snapshots-out/Snapshot.Tco05.js
@@ -1,14 +1,11 @@
-import * as $runtime from "../runtime.js";
-import * as Data$dArray from "../Data.Array/index.js";
 import * as Data$dMaybe from "../Data.Maybe/index.js";
 const span = p => arr => {
   const go = go$a0$copy => {
     let go$a0 = go$a0$copy, go$c = true, go$r;
     while (go$c) {
       const i = go$a0;
-      const v = Data$dArray.index(arr)(i);
-      if (v.tag === "Just") {
-        if (p(v._1)) {
+      if (i >= 0 && i < arr.length) {
+        if (p(arr[i])) {
           go$a0 = i + 1 | 0;
           continue;
         }
@@ -16,12 +13,8 @@ const span = p => arr => {
         go$r = Data$dMaybe.$Maybe("Just", i);
         continue;
       }
-      if (v.tag === "Nothing") {
-        go$c = false;
-        go$r = Data$dMaybe.Nothing;
-        continue;
-      }
-      $runtime.fail();
+      go$c = false;
+      go$r = Data$dMaybe.Nothing;
     }
     return go$r;
   };

--- a/backend-es/test/snapshots/Snapshot.InlineArrayIndex.purs
+++ b/backend-es/test/snapshots/Snapshot.InlineArrayIndex.purs
@@ -1,0 +1,36 @@
+-- @inline export testArrayIndex never
+module Snapshot.InlineArrayIndex where
+
+import Prelude
+
+import Assert (assertEqual)
+import Data.Array as Array
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+
+testArrayIndex :: forall a. Array a -> Int -> Maybe a
+testArrayIndex arr ix = Array.index arr ix
+
+main :: Effect Unit
+main = do
+  let array = [ 1, 2, 3 ]
+  assertEqual "index -1"
+    { expected: Nothing
+    , actual: testArrayIndex array (-1)
+    }
+  assertEqual "index 0"
+    { expected: Just 1
+    , actual: testArrayIndex array 0
+    }
+  assertEqual "index 1"
+    { expected: Just 2
+    , actual: testArrayIndex array 1
+    }
+  assertEqual "index 2"
+    { expected: Just 3
+    , actual: testArrayIndex array 2
+    }
+  assertEqual "index 3"
+    { expected: Nothing
+    , actual: testArrayIndex array 3
+    }

--- a/packages.dhall
+++ b/packages.dhall
@@ -24,3 +24,4 @@ in  upstream
     , repo = "https://github.com/natefaubion/purescript-node-glob-basic.git"
     , version = "v1.2.2"
     }
+  with arrays.version = "v7.2.1"

--- a/src/PureScript/Backend/Optimizer/Semantics/Foreign.purs
+++ b/src/PureScript/Backend/Optimizer/Semantics/Foreign.purs
@@ -13,7 +13,7 @@ import Data.Maybe (Maybe(..))
 import Data.String as String
 import Data.Tuple (Tuple(..))
 import PureScript.Backend.Optimizer.CoreFn (Ident(..), Literal(..), ModuleName(..), Prop(..), Qualified(..), propKey)
-import PureScript.Backend.Optimizer.Semantics (BackendSemantics(..), Env, ExternSpine(..), SemConditional(..), evalAccessor, evalApp, evalMkFn, evalPrimOp, evalUncurriedApp, evalUncurriedEffectApp, evalUpdate, liftBoolean, liftInt, makeLet)
+import PureScript.Backend.Optimizer.Semantics (BackendSemantics(..), Env, ExternSpine(..), evalAccessor, evalApp, evalMkFn, evalPrimOp, evalUncurriedApp, evalUncurriedEffectApp, evalUpdate, liftBoolean, makeLet)
 import PureScript.Backend.Optimizer.Syntax (BackendAccessor(..), BackendEffect(..), BackendOperator(..), BackendOperator1(..), BackendOperator2(..), BackendOperatorNum(..), BackendOperatorOrd(..))
 
 type ForeignEval =
@@ -37,7 +37,6 @@ coreForeignSemantics = Map.fromFoldable semantics
     , control_monad_st_internal_read
     , control_monad_st_internal_run
     , control_monad_st_internal_write
-    , data_array_indexImpl
     , data_array_length
     , data_array_unsafeIndexImpl
     , data_eq_eqBooleanImpl
@@ -158,29 +157,6 @@ data_array_unsafeIndexImpl = Tuple (qualified "Data.Array" "unsafeIndexImpl") go
       Just $ makeLet Nothing a \a' ->
         SemLam Nothing \b' ->
           evalPrimOp env (Op2 OpArrayIndex a' b')
-    _ ->
-      Nothing
-
-data_array_indexImpl :: ForeignSemantics
-data_array_indexImpl = Tuple (qualified "Data.Array" "indexImpl") go
-  where
-  go env _ = case _ of
-    [ ExternUncurriedApp [ just, nothing, arr, ix ] ] ->
-      Just $ makeLet Nothing arr \arr' ->
-        makeLet Nothing ix \ix' ->
-          SemBranch
-            ( NonEmptyArray.singleton $ SemConditional
-                ( Lazy.defer \_ ->
-                    evalPrimOp env $ Op2 OpBooleanAnd
-                      (evalPrimOp env (Op2 (OpIntOrd OpGte) ix' (liftInt 0)))
-                      (evalPrimOp env (Op2 (OpIntOrd OpLt) ix' (evalPrimOp env (Op1 OpArrayLength arr'))))
-                )
-                ( Lazy.defer \_ ->
-                    evalApp env just
-                      [ evalPrimOp env (Op2 OpArrayIndex arr' ix') ]
-                )
-            )
-            (pure nothing)
     _ ->
       Nothing
 


### PR DESCRIPTION
* This mainly affects Array.index and Array.unsafeIndex.
* I've updated `unsafeIndexImpl` such that it should still work on old versions of `arrays` by casing on the different calling conventions.
* I've inlined semantics for the `indexImpl` bounds checks, which exposes some optimizations. There are two snapshots that are updated to elide the allocation of the Just constructor.
* STArray ops seem to still be OK, but we are now overriding _non-foreign_ definitions. I haven't changed anything here because I want old versions of `arrays` to still work.