### PR TITLE
Floats let bindings

### DIFF
--- a/backend-es/test/snapshots-out/Snapshot.FloatLetFromApp.js
+++ b/backend-es/test/snapshots-out/Snapshot.FloatLetFromApp.js
@@ -1,0 +1,29 @@
+import * as $runtime from "../runtime.js";
+import * as Data$dEither from "../Data.Either/index.js";
+import * as Data$dFoldable from "../Data.Foldable/index.js";
+import * as Data$dTuple from "../Data.Tuple/index.js";
+import * as Effect$dConsole from "../Effect.Console/index.js";
+const test1 = /* #__PURE__ */ Data$dTuple.$Tuple(
+  1,
+  /* #__PURE__ */ (() => {
+    const b = Effect$dConsole.log("foo");
+    const a = Data$dFoldable.foldlArray(a => b$1 => {
+      if (a.tag === "Left") { return Data$dEither.$Either("Left", a._1); }
+      if (a.tag === "Right") {
+        if (b$1.tag === "Left") { return Data$dEither.$Either("Left", b$1._1); }
+        if (b$1.tag === "Right") { return Data$dEither.$Either("Right", a._1 + b$1._1 | 0); }
+        $runtime.fail();
+      }
+      $runtime.fail();
+    })(Data$dEither.$Either("Right", 3))([Data$dEither.$Either("Left", b), Data$dEither.$Either("Right", 4), Data$dEither.$Either("Left", b)]);
+    return Data$dTuple.$Tuple(
+      a,
+      (() => {
+        if (a.tag === "Left") { return Data$dEither.$Either("Left", a._1); }
+        if (a.tag === "Right") { return Data$dEither.$Either("Right", a._1 + 1 | 0); }
+        $runtime.fail();
+      })()
+    );
+  })()
+);
+export {test1};

--- a/backend-es/test/snapshots-out/Snapshot.FloatLetFromArray.js
+++ b/backend-es/test/snapshots-out/Snapshot.FloatLetFromArray.js
@@ -1,0 +1,33 @@
+import * as $runtime from "../runtime.js";
+import * as Data$dEither from "../Data.Either/index.js";
+import * as Effect$dConsole from "../Effect.Console/index.js";
+const snd = a => a[1];
+const right = x => {
+  if (x.tag === "Right") { return x._1; }
+  $runtime.fail();
+};
+const left = x => {
+  if (x.tag === "Left") { return x._1; }
+  $runtime.fail();
+};
+const fst = a => a[0];
+const test1 = [
+  /* #__PURE__ */ Data$dEither.$Either("Left", 5),
+  /* #__PURE__ */ (() => {
+    const b = Effect$dConsole.log("foo");
+    return Data$dEither.$Either(
+      "Right",
+      [
+        Data$dEither.$Either(
+          "Left",
+          [
+            Data$dEither.$Either("Left", 1),
+            Data$dEither.$Either("Right", [Data$dEither.$Either("Left", b), Data$dEither.$Either("Right", [Data$dEither.$Either("Left", 5), Data$dEither.$Either("Right", b)])])
+          ]
+        ),
+        Data$dEither.$Either("Right", 6)
+      ]
+    );
+  })()
+];
+export {fst, left, right, snd, test1};

--- a/backend-es/test/snapshots-out/Snapshot.FloatLetFromCtor.js
+++ b/backend-es/test/snapshots-out/Snapshot.FloatLetFromCtor.js
@@ -1,0 +1,10 @@
+import * as Data$dTuple from "../Data.Tuple/index.js";
+import * as Effect$dConsole from "../Effect.Console/index.js";
+const test1 = /* #__PURE__ */ Data$dTuple.$Tuple(
+  5,
+  /* #__PURE__ */ (() => {
+    const b = Effect$dConsole.log("foo");
+    return Data$dTuple.$Tuple(Data$dTuple.$Tuple(1, Data$dTuple.$Tuple(b, Data$dTuple.$Tuple(5, b))), 6);
+  })()
+);
+export {test1};

--- a/backend-es/test/snapshots-out/Snapshot.FloatLetFromRecord.js
+++ b/backend-es/test/snapshots-out/Snapshot.FloatLetFromRecord.js
@@ -1,0 +1,9 @@
+import * as Effect$dConsole from "../Effect.Console/index.js";
+const test1 = {
+  l: 5,
+  r: /* #__PURE__ */ (() => {
+    const b = Effect$dConsole.log("foo");
+    return {l: {l: 1, r: {l: b, r: {l: 5, r: b}}}, r: 6};
+  })()
+};
+export {test1};

--- a/backend-es/test/snapshots-out/Snapshot.FunctionCompose03.js
+++ b/backend-es/test/snapshots-out/Snapshot.FunctionCompose03.js
@@ -14,10 +14,10 @@ const test3 = f => g => {
   return x => $0($1($2($3(x))));
 };
 const test2 = f => g => {
-  const $0 = g();
-  const $1 = f();
+  const $0 = f();
+  const $1 = g();
   const $2 = g();
-  return x => $0($1($2(x)));
+  return x => $2($0($1(x)));
 };
 const test1 = f => g => {
   const $0 = f();

--- a/backend-es/test/snapshots-out/Snapshot.Fusion01.js
+++ b/backend-es/test/snapshots-out/Snapshot.Fusion01.js
@@ -7,7 +7,7 @@ import * as Data$dShow from "../Data.Show/index.js";
 import * as Data$dString$dCodeUnits from "../Data.String.CodeUnits/index.js";
 import * as Data$dUnfoldable from "../Data.Unfoldable/index.js";
 const toUnfoldable = /* #__PURE__ */ Data$dList.toUnfoldable(Data$dUnfoldable.unfoldableArray);
-const test = x => Data$dArray.reverse(toUnfoldable((() => {
+const test = x => {
   const loop = loop$a0$copy => loop$a1$copy => {
     let loop$a0 = loop$a0$copy, loop$a1 = loop$a1$copy, loop$c = true, loop$r;
     while (loop$c) {
@@ -17,9 +17,9 @@ const test = x => Data$dArray.reverse(toUnfoldable((() => {
         loop$r = acc;
         continue;
       }
+      const v1 = Data$dString$dCodeUnits.stripPrefix("1")(Data$dShow.showIntImpl(1 + x[n] | 0));
       loop$a0 = n - 1 | 0;
       loop$a1 = (() => {
-        const v1 = Data$dString$dCodeUnits.stripPrefix("1")(Data$dShow.showIntImpl(1 + x[n] | 0));
         if (v1.tag === "Just") {
           const $0 = "2" + v1._1;
           if ($0 !== "wat") { return Data$dList$dTypes.$List("Cons", $0 + "1", acc); }
@@ -31,6 +31,6 @@ const test = x => Data$dArray.reverse(toUnfoldable((() => {
     }
     return loop$r;
   };
-  return loop(x.length - 1 | 0)(Data$dList$dTypes.Nil);
-})()));
+  return Data$dArray.reverse(toUnfoldable(loop(x.length - 1 | 0)(Data$dList$dTypes.Nil)));
+};
 export {test, toUnfoldable};

--- a/backend-es/test/snapshots-out/Snapshot.InlineDirectivePropSpine01.js
+++ b/backend-es/test/snapshots-out/Snapshot.InlineDirectivePropSpine01.js
@@ -3,14 +3,10 @@
 import * as Type$dEquality from "../Type.Equality/index.js";
 const wat = dict => dict.wat;
 const testImpl = x => x;
-const watUnit = dictTypeEquals => (
-  {
-    wat: (() => {
-      const $0 = dictTypeEquals.proof(a => a);
-      return x => testImpl($0(x));
-    })()
-  }
-);
+const watUnit = dictTypeEquals => {
+  const $0 = dictTypeEquals.proof(a => a);
+  return {wat: x => testImpl($0(x))};
+};
 const wat1 = /* #__PURE__ */ (() => watUnit(Type$dEquality.refl).wat)();
 const g = wat1;
 const test2 = /* #__PURE__ */ testImpl();

--- a/backend-es/test/snapshots/Snapshot.FloatLetFromApp.purs
+++ b/backend-es/test/snapshots/Snapshot.FloatLetFromApp.purs
@@ -1,0 +1,17 @@
+module Snapshot.FloatLetFromApp where
+
+import Prelude
+
+import Control.Apply (lift2)
+import Data.Array (foldl)
+import Data.Either (Either(..))
+import Data.Tuple (Tuple(..))
+import Effect (Effect)
+import Effect.Console (log)
+
+test1 ∷ Tuple Int (Tuple (Either (Effect Unit) Int) (Either (Effect Unit) Int))
+test1 = Tuple 1
+  let
+    a = foldl (lift2 (+)) (Right 3) let b = log "foo" in [Left b, Right 4, Left b]
+  in
+    Tuple a ((_ + 1) <$> a)

--- a/backend-es/test/snapshots/Snapshot.FloatLetFromArray.purs
+++ b/backend-es/test/snapshots/Snapshot.FloatLetFromArray.purs
@@ -1,0 +1,27 @@
+module Snapshot.FloatLetFromArray where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Either (Either(..))
+import Effect (Effect)
+import Effect.Console (log)
+import Partial.Unsafe (unsafePartial)
+
+fst :: forall (a :: Type). Array (a) -> a
+fst a = unsafePartial $ Array.unsafeIndex a 0
+
+snd :: forall (a :: Type). Array (a) -> a
+snd a = unsafePartial $ Array.unsafeIndex a 1
+
+left :: forall (a :: Type) (b :: Type). Either a b -> a
+left = unsafePartial <<< case _ of
+  Left x -> x
+
+right :: forall b a. Either a b -> b
+right = unsafePartial <<< case _ of
+  Right x -> x
+
+test1 :: Array (Either Int (Array (Either (Array (Either Int (Array (Either (Effect Unit) (Array (Either Int (Effect Unit))))))) Int)))
+test1 =
+  [ Left 5, let a = [ Left 1, let b = log "foo" in Right [ Left b, Right [ Left 5, Right b ] ] ] in Right [ Left a, Right (1 + (left $ fst $ right $ snd $ right $ snd a)) ] ]

--- a/backend-es/test/snapshots/Snapshot.FloatLetFromCtor.purs
+++ b/backend-es/test/snapshots/Snapshot.FloatLetFromCtor.purs
@@ -1,0 +1,14 @@
+module Snapshot.FloatLetFromCtor where
+
+import Prelude
+
+import Data.Tuple (Tuple(..), fst, snd)
+import Effect (Effect)
+import Effect.Console (log)
+
+test1 :: Tuple Int (Tuple (Tuple Int (Tuple (Effect Unit) (Tuple Int (Effect Unit)))) Int)
+test1 = Tuple 5
+  let
+    a = Tuple 1 let b = log "foo" in Tuple b (Tuple 5 b)
+  in
+    Tuple a (1 + (fst $ snd $ snd a))

--- a/backend-es/test/snapshots/Snapshot.FloatLetFromRecord.purs
+++ b/backend-es/test/snapshots/Snapshot.FloatLetFromRecord.purs
@@ -1,0 +1,31 @@
+module Snapshot.FloatLetFromRecord where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Console (log)
+
+test1
+  :: { l :: Int
+     , r ::
+         { l ::
+             { l :: Int
+             , r ::
+                 { l :: Effect Unit
+                 , r ::
+                     { l :: Int
+                     , r :: Effect Unit
+                     }
+                 }
+             }
+         , r :: Int
+         }
+     }
+test1 =
+  { l: 5
+  , r:
+      let
+        a = { l: 1, r: let b = log "foo" in { l: b, r: { l: 5, r: b } } }
+      in
+        { l: a, r: 1 + (a.r.r.l) }
+  }

--- a/spago.dhall
+++ b/spago.dhall
@@ -21,6 +21,7 @@ You can edit this file as you like.
   , "filterable"
   , "foldable-traversable"
   , "foreign-object"
+  , "free"
   , "integers"
   , "language-cst-parser"
   , "lazy"

--- a/src/PureScript/Backend/Optimizer/Convert.purs
+++ b/src/PureScript/Backend/Optimizer/Convert.purs
@@ -243,7 +243,7 @@ type OptimizationSteps = Array (Tuple (Qualified Ident) (NonEmptyArray BackendEx
 
 toTopLevelBackendBinding :: Array (Qualified Ident) -> ConvertEnv -> Binding Ann -> Accum ConvertEnv (Tuple Ident (WithDeps NeutralExpr))
 toTopLevelBackendBinding group env (Binding _ ident cfn) = do
-  let evalEnv = Env { currentModule: env.currentModule, evalExternRef: makeExternEvalRef env, evalExternSpine: makeExternEvalSpine env, locals: [], directives: env.directives }
+  let evalEnv = Env { atTop: true, currentModule: env.currentModule, evalExternRef: makeExternEvalRef env, evalExternSpine: makeExternEvalSpine env, locals: [], directives: env.directives }
   let qualifiedIdent = Qualified (Just env.currentModule) ident
   let backendExpr = toBackendExpr cfn env
   let enableTracing = Set.member qualifiedIdent env.traceIdents


### PR DESCRIPTION
Floats let bindings when strictness allows. This makes it easier to reason about `BackendSemantics` because, when we case on something, there's a higher chance that its subtree won't have closures from `let` bindings.