### PR TITLE
Improve associative operator handling

### DIFF
--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Inline.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Inline.purs
@@ -28,6 +28,7 @@ esInlineMap = Map.fromFoldable
   , data_array_st_new
   , data_array_st_pushAll
   , data_array_st_unshiftAll
+  , data_semigroup_concatArray
   , effect_forE
   , effect_foreachE
   , effect_whileE
@@ -84,6 +85,15 @@ arraySTAll method env _ = case _ of
     Just $ makeThunk $ build $ EsCall (build (EsAccess (codegenExpr env arr) method)) $ spreadConcatArray $ codegenExpr env vals
   _ ->
     Nothing
+
+data_semigroup_concatArray :: EsInline
+data_semigroup_concatArray = Tuple (qualified "Data.Semigroup" "concatArray") go
+  where
+  go env _ = case _ of
+    InlineApp [ a, b ] ->
+      Just $ build $ EsArray $ spreadConcatArray (codegenExpr env a) <> spreadConcatArray (codegenExpr env b)
+    _ ->
+      Nothing
 
 effect_forE :: EsInline
 effect_forE = Tuple (qualified "Effect" "forE") forRangeLoop

--- a/backend-es/test/snapshots-out/Snapshot.AssocArrayAppend.js
+++ b/backend-es/test/snapshots-out/Snapshot.AssocArrayAppend.js
@@ -1,0 +1,4 @@
+const test3 = x => ["a", "b", ...x, ...x, ...x, ...x, "c", "d", "e", ...x, ...x, ...x, ...x, "f", "g"];
+const test2 = x => ["a", "b", ...x, ...x, ...x, ...x, "c", "d"];
+const test1 = x => ["a", "b", ...x, ...x, ...x, ...x, "c", "d"];
+export {test1, test2, test3};

--- a/backend-es/test/snapshots-out/Snapshot.AssocIntOps.js
+++ b/backend-es/test/snapshots-out/Snapshot.AssocIntOps.js
@@ -1,0 +1,7 @@
+const test6 = x => (((((((((2 * x | 0) * x | 0) * x | 0) * x | 0) * 60 | 0) * x | 0) * x | 0) * x | 0) * x | 0) * 42 | 0;
+const test5 = x => ((((2 * x | 0) * x | 0) * x | 0) * x | 0) * 12 | 0;
+const test4 = x => ((((2 * x | 0) * x | 0) * x | 0) * x | 0) * 12 | 0;
+const test3 = x => (((((((((3 + x | 0) + x | 0) + x | 0) + x | 0) + 12 | 0) + x | 0) + x | 0) + x | 0) + x | 0) + 13 | 0;
+const test2 = x => ((((3 + x | 0) + x | 0) + x | 0) + x | 0) + 7 | 0;
+const test1 = x => ((((3 + x | 0) + x | 0) + x | 0) + x | 0) + 7 | 0;
+export {test1, test2, test3, test4, test5, test6};

--- a/backend-es/test/snapshots-out/Snapshot.AssocNumberOps.js
+++ b/backend-es/test/snapshots-out/Snapshot.AssocNumberOps.js
@@ -1,0 +1,7 @@
+const test6 = x => 2.0 * x * x * x * x * 60.0 * x * x * x * x * 42.0;
+const test5 = x => 2.0 * x * x * x * x * 12.0;
+const test4 = x => 2.0 * x * x * x * x * 12.0;
+const test3 = x => 3.0 + x + x + x + x + 12.0 + x + x + x + x + 13.0;
+const test2 = x => 3.0 + x + x + x + x + 7.0;
+const test1 = x => 3.0 + x + x + x + x + 7.0;
+export {test1, test2, test3, test4, test5, test6};

--- a/backend-es/test/snapshots-out/Snapshot.AssocStringAppend.js
+++ b/backend-es/test/snapshots-out/Snapshot.AssocStringAppend.js
@@ -1,0 +1,4 @@
+const test3 = x => "ab" + x + x + x + x + "cde" + x + x + x + x + "fg";
+const test2 = x => "ab" + x + x + x + x + "cd";
+const test1 = x => "ab" + x + x + x + x + "cd";
+export {test1, test2, test3};

--- a/backend-es/test/snapshots-out/Snapshot.CaseLeafTco.js
+++ b/backend-es/test/snapshots-out/Snapshot.CaseLeafTco.js
@@ -1,6 +1,5 @@
 import * as $runtime from "../runtime.js";
 import * as Data$dArray from "../Data.Array/index.js";
-import * as Data$dSemigroup from "../Data.Semigroup/index.js";
 const test1 = test1$a0$copy => test1$a1$copy => {
   let test1$a0 = test1$a0$copy, test1$a1 = test1$a1$copy, test1$c = true, test1$r;
   while (test1$c) {
@@ -14,7 +13,7 @@ const test1 = test1$a0$copy => test1$a1$copy => {
           return;
         }
         test1$a0 = b;
-        test1$a1 = Data$dSemigroup.concatArray([y, x, 3, y, 5, 6, 7, 8, 9, 10, x, 12, 13, 14, 15, 16, 17])(arr);
+        test1$a1 = [y, x, 3, y, 5, 6, 7, 8, 9, 10, x, 12, 13, 14, 15, 16, 17, ...arr];
       };
       if (v.tag === "Just") {
         if (v._1 === 2) {
@@ -31,7 +30,7 @@ const test1 = test1$a0$copy => test1$a1$copy => {
       }
       if (v.tag === "Nothing") {
         test1$c = false;
-        test1$r = Data$dSemigroup.concatArray(arr)([arr[0]]);
+        test1$r = [...arr, arr[0]];
         continue;
       }
       $runtime.fail();
@@ -39,11 +38,11 @@ const test1 = test1$a0$copy => test1$a1$copy => {
     if (v.tag === "Just") {
       if (v._1 === 2) {
         test1$c = false;
-        test1$r = Data$dSemigroup.concatArray(arr)([v._1]);
+        test1$r = [...arr, v._1];
         continue;
       }
       test1$c = false;
-      test1$r = Data$dSemigroup.concatArray(arr)([v._1]);
+      test1$r = [...arr, v._1];
       continue;
     }
     if (v.tag === "Nothing") {

--- a/backend-es/test/snapshots-out/Snapshot.DefaultRulesSemigroup02.js
+++ b/backend-es/test/snapshots-out/Snapshot.DefaultRulesSemigroup02.js
@@ -1,7 +1,6 @@
-import * as Data$dSemigroup from "../Data.Semigroup/index.js";
-const append = ra => rb => ({bar: Data$dSemigroup.concatArray(ra.bar)(rb.bar), foo: ra.foo + rb.foo});
+const append = ra => rb => ({bar: [...ra.bar, ...rb.bar], foo: ra.foo + rb.foo});
 const test4 = {bar: ["hello", "World!"], foo: "hello, World!"};
 const test3 = /* #__PURE__ */ append({foo: "hello", bar: ["hello"]});
-const test2 = a => b => ({bar: Data$dSemigroup.concatArray(a.bar)(b.bar), foo: a.foo + b.foo});
+const test2 = a => b => ({bar: [...a.bar, ...b.bar], foo: a.foo + b.foo});
 const test1 = append;
 export {append, test1, test2, test3, test4};

--- a/backend-es/test/snapshots-out/Snapshot.EffectBind06.js
+++ b/backend-es/test/snapshots-out/Snapshot.EffectBind06.js
@@ -3,6 +3,6 @@ const test = random => () => {
   const x1 = random();
   const y = random();
   const m = random();
-  return (x + (x1 + y | 0) | 0) - m | 0;
+  return ((x + x1 | 0) + y | 0) - m | 0;
 };
 export {test};

--- a/backend-es/test/snapshots-out/Snapshot.EffectBind07.js
+++ b/backend-es/test/snapshots-out/Snapshot.EffectBind07.js
@@ -6,6 +6,6 @@ const test = random => value => () => {
   const x1 = random();
   const y = random();
   const m = random();
-  return (x + (((x1 + y | 0) + a | 0) + a | 0) | 0) - m | 0;
+  return ((((x + x1 | 0) + y | 0) + a | 0) + a | 0) - m | 0;
 };
 export {test};

--- a/backend-es/test/snapshots-out/Snapshot.HalogenVDomST02.js
+++ b/backend-es/test/snapshots-out/Snapshot.HalogenVDomST02.js
@@ -4,10 +4,10 @@ import * as Data$dEq from "../Data.Eq/index.js";
 import * as Data$dShow from "../Data.Show/index.js";
 import * as Snapshot$dHalogenVDomST01 from "../Snapshot.HalogenVDomST01/index.js";
 const assertEqual = /* #__PURE__ */ Assert.assertEqual({eq: /* #__PURE__ */ Data$dEq.eqArrayImpl(ra => rb => ra.a === rb.a && ra.b === rb.b)})({
-  show: /* #__PURE__ */ Data$dShow.showArrayImpl(record => "{ a: " + Data$dShow.showStringImpl(record.a) + ", b: " + Data$dShow.showIntImpl(record.b) + " " + "}")
+  show: /* #__PURE__ */ Data$dShow.showArrayImpl(record => "{ a: " + Data$dShow.showStringImpl(record.a) + ", b: " + Data$dShow.showIntImpl(record.b) + " }")
 });
 const assertEqual3 = /* #__PURE__ */ Assert.assertEqual({eq: /* #__PURE__ */ Data$dEq.eqArrayImpl(ra => rb => ra.a === rb.a && ra.b === rb.b && ra.ix === rb.ix)})({
-  show: /* #__PURE__ */ Data$dShow.showArrayImpl(record => "{ a: " + Data$dShow.showStringImpl(record.a) + ", b: " + Data$dShow.showIntImpl(record.b) + ", ix: " + Data$dShow.showIntImpl(record.ix) + " " + "}")
+  show: /* #__PURE__ */ Data$dShow.showArrayImpl(record => "{ a: " + Data$dShow.showStringImpl(record.a) + ", b: " + Data$dShow.showIntImpl(record.b) + ", ix: " + Data$dShow.showIntImpl(record.ix) + " }")
 });
 const main = () => {
   const merged1 = [];

--- a/backend-es/test/snapshots/Snapshot.AssocArrayAppend.purs
+++ b/backend-es/test/snapshots/Snapshot.AssocArrayAppend.purs
@@ -1,0 +1,12 @@
+module Snapshot.AssocArrayAppend where
+
+import Prelude
+
+test1 :: Array String -> Array String
+test1 x = [ "a" ] <> ((((([ "b" ] <> x) <> x) <> x) <> x) <> [ "c" ]) <> [ "d" ]
+
+test2 :: Array String -> Array String
+test2 x = [ "a" ] <> ([ "b" ] <> (x <> (x <> (x <> (x <> [ "c" ]))))) <> [ "d" ]
+
+test3 :: Array String -> Array String
+test3 x = [ "a" ] <> ([ "b" ] <> (x <> (x <> (x <> (x <> [ "c" ]))))) <> [ "d" ] <> ((((([ "e" ] <> x) <> x) <> x) <> x) <> [ "f" ]) <> [ "g" ]

--- a/backend-es/test/snapshots/Snapshot.AssocIntOps.purs
+++ b/backend-es/test/snapshots/Snapshot.AssocIntOps.purs
@@ -1,0 +1,21 @@
+module Snapshot.AssocIntOps where
+
+import Prelude
+
+test1 :: Int -> Int
+test1 x = 1 + (((((2 + x) + x) + x) + x) + 3) + 4
+
+test2 :: Int -> Int
+test2 x = 1 + (2 + (x + (x + (x + (x + 3))))) + 4
+
+test3 :: Int -> Int
+test3 x = 1 + (2 + (x + (x + (x + (x + 3))))) + 4 + (((((5 + x) + x) + x) + x) + 6) + 7
+
+test4 :: Int -> Int
+test4 x = 1 * (((((2 * x) * x) * x) * x) * 3) * 4
+
+test5 :: Int -> Int
+test5 x = 1 * (2 * (x * (x * (x * (x * 3))))) * 4
+
+test6 :: Int -> Int
+test6 x = 1 * (2 * (x * (x * (x * (x * 3))))) * 4 * (((((5 * x) * x) * x) * x) * 6) * 7

--- a/backend-es/test/snapshots/Snapshot.AssocNumberOps.purs
+++ b/backend-es/test/snapshots/Snapshot.AssocNumberOps.purs
@@ -1,0 +1,21 @@
+module Snapshot.AssocNumberOps where
+
+import Prelude
+
+test1 :: Number -> Number
+test1 x = 1.0 + (((((2.0 + x) + x) + x) + x) + 3.0) + 4.0
+
+test2 :: Number -> Number
+test2 x = 1.0 + (2.0 + (x + (x + (x + (x + 3.0))))) + 4.0
+
+test3 :: Number -> Number
+test3 x = 1.0 + (2.0 + (x + (x + (x + (x + 3.0))))) + 4.0 + (((((5.0 + x) + x) + x) + x) + 6.0) + 7.0
+
+test4 :: Number -> Number
+test4 x = 1.0 * (((((2.0 * x) * x) * x) * x) * 3.0) * 4.0
+
+test5 :: Number -> Number
+test5 x = 1.0 * (2.0 * (x * (x * (x * (x * 3.0))))) * 4.0
+
+test6 :: Number -> Number
+test6 x = 1.0 * (2.0 * (x * (x * (x * (x * 3.0))))) * 4.0 * (((((5.0 * x) * x) * x) * x) * 6.0) * 7.0

--- a/backend-es/test/snapshots/Snapshot.AssocStringAppend.purs
+++ b/backend-es/test/snapshots/Snapshot.AssocStringAppend.purs
@@ -1,0 +1,12 @@
+module Snapshot.AssocStringAppend where
+
+import Prelude
+
+test1 :: String -> String
+test1 x = "a" <> ((((("b" <> x) <> x) <> x) <> x) <> "c") <> "d"
+
+test2 :: String -> String
+test2 x = "a" <> ("b" <> (x <> (x <> (x <> (x <> "c"))))) <> "d"
+
+test3 :: String -> String
+test3 x = "a" <> ("b" <> (x <> (x <> (x <> (x <> "c"))))) <> "d" <> ((((("e" <> x) <> x) <> x) <> x) <> "f") <> "g"

--- a/src/PureScript/Backend/Optimizer/Semantics/Foreign.purs
+++ b/src/PureScript/Backend/Optimizer/Semantics/Foreign.purs
@@ -4,8 +4,8 @@ import Prelude
 
 import Data.Array as Array
 import Data.Array.NonEmpty as NonEmptyArray
+import Data.Either (Either(..))
 import Data.Enum (fromEnum)
-import Data.Lazy (defer)
 import Data.List as List
 import Data.Map (Map)
 import Data.Map as Map
@@ -13,7 +13,7 @@ import Data.Maybe (Maybe(..))
 import Data.String as String
 import Data.Tuple (Tuple(..))
 import PureScript.Backend.Optimizer.CoreFn (Ident(..), Literal(..), ModuleName(..), Prop(..), Qualified(..), propKey)
-import PureScript.Backend.Optimizer.Semantics (BackendSemantics(..), Env, EvalRef(..), ExternSpine(..), evalAccessor, evalApp, evalMkFn, evalPrimOp, evalUncurriedApp, evalUncurriedEffectApp, evalUpdate, liftBoolean, makeLet)
+import PureScript.Backend.Optimizer.Semantics (BackendSemantics(..), Env, EvalRef(..), ExternSpine(..), evalAccessor, evalApp, evalAssocOp, evalMkFn, evalPrimOp, evalUncurriedApp, evalUncurriedEffectApp, evalUpdate, liftBoolean, makeLet)
 import PureScript.Backend.Optimizer.Syntax (BackendAccessor(..), BackendEffect(..), BackendOperator(..), BackendOperator1(..), BackendOperator2(..), BackendOperatorNum(..), BackendOperatorOrd(..))
 
 type ForeignEval =
@@ -431,90 +431,19 @@ isQualified mod tag = case _ of
   _ ->
     false
 
-assocBinaryOperatorL
-  :: forall a
-   . (BackendSemantics -> Maybe a)
-  -> (Env -> a -> a -> BackendSemantics)
-  -> (Env -> BackendSemantics -> BackendSemantics -> Maybe BackendSemantics)
-  -> ForeignEval
-assocBinaryOperatorL match op def env ident = case _ of
-  [ ExternApp [ a, b ] ] ->
-    case rewrite of
-      Just _ ->
-        rewrite
-      Nothing ->
-        def env a b
-    where
-    rewrite = case match a of
-      Just lhs ->
-        case match b of
-          Just rhs ->
-            Just $ op env lhs rhs
-          Nothing ->
-            case b of
-              SemRef (EvalExtern ident') [ ExternApp [ x, y ] ] _ | ident == ident' ->
-                case match x of
-                  Just rhs -> do
-                    let result = op env lhs rhs
-                    Just $ externApp env ident [ result, y ]
-                  Nothing ->
-                    case x of
-                      SemRef (EvalExtern ident'') [ ExternApp [ v, w ] ] _ | ident == ident'' ->
-                        case match v of
-                          Just rhs -> do
-                            let result = op env lhs rhs
-                            Just $ externApp env ident [ externApp env ident [ result, w ], y ]
-                          Nothing ->
-                            Nothing
-                      _ ->
-                        Nothing
-              _ ->
-                Nothing
-      Nothing ->
-        case match b of
-          Just rhs ->
-            case a of
-              SemRef (EvalExtern ident') [ ExternApp [ v, w ] ] _ | ident == ident' ->
-                case match w of
-                  Just lhs -> do
-                    let result = op env lhs rhs
-                    Just $ externApp env ident [ v, result ]
-                  Nothing ->
-                    case w of
-                      SemRef (EvalExtern ident'') [ ExternApp [ x, y ] ] _ | ident == ident'' ->
-                        case match y of
-                          Just lhs -> do
-                            let result = op env lhs rhs
-                            Just $ externApp env ident [ externApp env ident [ v, x ], result ]
-                          Nothing ->
-                            Nothing
-                      _ ->
-                        Nothing
-              _ ->
-                Nothing
-          Nothing ->
-            Nothing
-  _ ->
-    Nothing
-
 data_semigroup_concatArray :: ForeignSemantics
-data_semigroup_concatArray = Tuple (qualified "Data.Semigroup" "concatArray") $ assocBinaryOperatorL match op default
+data_semigroup_concatArray = Tuple (qualified "Data.Semigroup" "concatArray") go
   where
-  match = case _ of
-    NeutLit (LitArray a) -> Just a
-    _ -> Nothing
-
-  op _ a b =
-    NeutLit (LitArray (a <> b))
-
-  default _ _ _ =
-    Nothing
+  go env qual = case _ of
+    [ ExternApp [ NeutLit (LitArray as), NeutLit (LitArray bs)]] ->
+      Just $ NeutLit (LitArray (as <> bs))
+    [ ExternApp [ a, b ] ] ->
+      Just $ evalAssocOp env (Left qual) a b
+    _ ->
+      Nothing
 
 data_semigroup_concatString :: ForeignSemantics
 data_semigroup_concatString = Tuple (qualified "Data.Semigroup" "concatString") $ primBinaryOperator OpStringAppend
-
-externApp :: Env -> Qualified Ident -> Array BackendSemantics -> BackendSemantics
-externApp env qual = evalApp env (SemRef (EvalExtern qual) [] (defer \_ -> NeutVar qual))
 
 partial_unsafe_unsafePartial :: ForeignSemantics
 partial_unsafe_unsafePartial = Tuple (qualified "Partial.Unsafe" "_unsafePartial") go


### PR DESCRIPTION
Previously, there were a couple of baroque routines for reassociating operators during eval advantageously. It only did this to a fixed depth because this can become quadratic. I've replaced this with a single baroque routine that solves it completely, const evaling anything it can, and reassociating everything to the left. To do this, I've added a new SemAssocOp node that's similar to SemRef, which buffers the operator spine. Then during quote we actually reassociate it.

I've also added special support for compiling concatArray calls to array spreads, which both looks nicer and is likely faster at runtime.