### PR TITLE
Extract corefn helpers to the library

### DIFF
--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Builder.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Builder.purs
@@ -2,73 +2,28 @@ module PureScript.Backend.Optimizer.Codegen.EcmaScript.Builder where
 
 import Prelude
 
-import Control.Monad.Except (ExceptT(..), lift, runExceptT)
-import Control.Parallel (parTraverse)
-import Data.Argonaut as Json
-import Data.Array.NonEmpty (NonEmptyArray)
-import Data.Array.NonEmpty as NonEmptyArray
-import Data.Bifunctor (lmap)
-import Data.Compactable (separate)
 import Data.Either (Either(..))
-import Data.Foldable (foldl, for_)
-import Data.Lazy as Lazy
-import Data.List (List)
+import Data.Foldable (for_)
 import Data.Map (Map)
 import Data.Map as Map
-import Data.Maybe (maybe)
 import Data.Set (Set)
-import Data.Set as Set
-import Data.Set.NonEmpty as NonEmptySet
 import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff, parallel, sequential)
 import Effect.Class (liftEffect)
 import Effect.Class.Console as Console
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff as FS
-import Node.Glob.Basic (expandGlobs)
 import Node.Path (FilePath)
 import Node.Process as Process
 import PureScript.Backend.Optimizer.Builder (BuildEnv, buildModules)
 import PureScript.Backend.Optimizer.Convert (BackendModule, OptimizationSteps)
-import PureScript.Backend.Optimizer.CoreFn (Ann, Ident, Module, ModuleName(..), Qualified)
-import PureScript.Backend.Optimizer.CoreFn.Json (decodeModule)
-import PureScript.Backend.Optimizer.CoreFn.Sort (emptyPull, pullResult, resumePull, sortModules)
+import PureScript.Backend.Optimizer.CoreFn (Ann, Ident, Module, Qualified)
+import PureScript.Backend.Optimizer.CoreFn.FromFile (coreFnModulesFromOutput)
 import PureScript.Backend.Optimizer.Directives (parseDirectiveFile)
 import PureScript.Backend.Optimizer.Directives.Defaults as Defaults
 import PureScript.Backend.Optimizer.Semantics (InlineDirectiveMap)
 import PureScript.Backend.Optimizer.Semantics.Foreign (ForeignEval)
 import PureScript.CST.Errors (printParseError)
-
-coreFnModulesFromOutput :: String -> NonEmptyArray String -> Aff (Either (NonEmptyArray (Tuple FilePath String)) (List (Module Ann)))
-coreFnModulesFromOutput path globs = runExceptT do
-  paths <- Set.toUnfoldable <$> lift (expandGlobs path ((_ <> "/corefn.json") <$> NonEmptyArray.toArray globs))
-  case NonEmptyArray.toArray globs of
-    [ "**" ] ->
-      sortModules <$> modulesFromPaths paths
-    _ ->
-      go <<< foldl resumePull emptyPull =<< modulesFromPaths paths
-  where
-  modulesFromPaths paths = ExceptT do
-    { left, right } <- separate <$> parTraverse readCoreFnModule paths
-    pure $ maybe (Right right) Left $ NonEmptyArray.fromArray left
-
-  pathFromModuleName (ModuleName mn) =
-    path <> "/" <> mn <> "/corefn.json"
-
-  go pull = case pullResult pull of
-    Left needed ->
-      go <<< foldl resumePull pull =<< modulesFromPaths (pathFromModuleName <$> NonEmptySet.toUnfoldable needed)
-    Right modules ->
-      pure $ Lazy.force modules
-
-readCoreFnModule :: String -> Aff (Either (Tuple FilePath String) (Module Ann))
-readCoreFnModule filePath = do
-  contents <- FS.readTextFile UTF8 filePath
-  case lmap Json.printJsonDecodeError <<< decodeModule =<< Json.jsonParser contents of
-    Left err -> do
-      pure $ Left $ Tuple filePath err
-    Right mod ->
-      pure $ Right mod
 
 externalDirectivesFromFile :: FilePath -> Aff InlineDirectiveMap
 externalDirectivesFromFile filePath = do

--- a/backend-es/test/Main.purs
+++ b/backend-es/test/Main.purs
@@ -37,10 +37,10 @@ import Node.Path as Path
 import Node.Process as Process
 import PureScript.Backend.Optimizer.Builder (buildModules)
 import PureScript.Backend.Optimizer.Codegen.EcmaScript (codegenModule)
-import PureScript.Backend.Optimizer.Codegen.EcmaScript.Builder (coreFnModulesFromOutput)
 import PureScript.Backend.Optimizer.Codegen.EcmaScript.Foreign (esForeignSemantics)
 import PureScript.Backend.Optimizer.Convert (BackendModule)
 import PureScript.Backend.Optimizer.CoreFn (Comment(..), Ident(..), Module(..), ModuleName(..), Qualified(..))
+import PureScript.Backend.Optimizer.CoreFn.FromFile (coreFnModulesFromOutput)
 import PureScript.Backend.Optimizer.Directives (parseDirectiveFile)
 import PureScript.Backend.Optimizer.Directives.Defaults (defaultDirectives)
 import PureScript.Backend.Optimizer.Semantics.Foreign (coreForeignSemantics)

--- a/src/PureScript/Backend/Optimizer/CoreFn/FromFile.purs
+++ b/src/PureScript/Backend/Optimizer/CoreFn/FromFile.purs
@@ -1,0 +1,58 @@
+module PureScript.Backend.Optimizer.CoreFn.FromFile where
+
+import Prelude
+
+import Control.Monad.Except (ExceptT(..), lift, runExceptT)
+import Control.Parallel (parTraverse)
+import Data.Argonaut as Json
+import Data.Array.NonEmpty (NonEmptyArray)
+import Data.Array.NonEmpty as NonEmptyArray
+import Data.Bifunctor (lmap)
+import Data.Compactable (separate)
+import Data.Either (Either(..))
+import Data.Foldable (foldl)
+import Data.Lazy as Lazy
+import Data.List (List)
+import Data.Maybe (maybe)
+import Data.Set as Set
+import Data.Set.NonEmpty as NonEmptySet
+import Data.Tuple (Tuple(..))
+import Effect.Aff (Aff)
+import Node.Encoding (Encoding(..))
+import Node.FS.Aff as FS
+import Node.Glob.Basic (expandGlobs)
+import Node.Path (FilePath)
+import PureScript.Backend.Optimizer.CoreFn (Ann, Module, ModuleName(..))
+import PureScript.Backend.Optimizer.CoreFn.Json (decodeModule)
+import PureScript.Backend.Optimizer.CoreFn.Sort (emptyPull, pullResult, resumePull, sortModules)
+
+coreFnModulesFromOutput :: String -> NonEmptyArray String -> Aff (Either (NonEmptyArray (Tuple FilePath String)) (List (Module Ann)))
+coreFnModulesFromOutput path globs = runExceptT do
+  paths <- Set.toUnfoldable <$> lift (expandGlobs path ((_ <> "/corefn.json") <$> NonEmptyArray.toArray globs))
+  case NonEmptyArray.toArray globs of
+    [ "**" ] ->
+      sortModules <$> modulesFromPaths paths
+    _ ->
+      go <<< foldl resumePull emptyPull =<< modulesFromPaths paths
+  where
+  modulesFromPaths paths = ExceptT do
+    { left, right } <- separate <$> parTraverse readCoreFnModule paths
+    pure $ maybe (Right right) Left $ NonEmptyArray.fromArray left
+
+  pathFromModuleName (ModuleName mn) =
+    path <> "/" <> mn <> "/corefn.json"
+
+  go pull = case pullResult pull of
+    Left needed ->
+      go <<< foldl resumePull pull =<< modulesFromPaths (pathFromModuleName <$> NonEmptySet.toUnfoldable needed)
+    Right modules ->
+      pure $ Lazy.force modules
+
+readCoreFnModule :: String -> Aff (Either (Tuple FilePath String) (Module Ann))
+readCoreFnModule filePath = do
+  contents <- FS.readTextFile UTF8 filePath
+  case lmap Json.printJsonDecodeError <<< decodeModule =<< Json.jsonParser contents of
+    Left err -> do
+      pure $ Left $ Tuple filePath err
+    Right mod ->
+      pure $ Right mod


### PR DESCRIPTION
These seem common enough to extract out from `backend-es` to the library.