### PR TITLE
Generate empty CtorSaturated, optimize it in codegen instead

### DIFF
--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Convert.purs
@@ -293,6 +293,8 @@ codegenExpr env@(CodegenEnv { currentModule, inlineApp }) tcoExpr@(TcoExpr _ exp
       [ build $ EsReturn $ Just $ codegenCtor env currentModule ct ty tag $
           (build <<< EsIdent <<< Qualified Nothing <<< toEsIdent <<< Ident) <$> fields
       ]
+  CtorSaturated qual _ _ _ [] ->
+    codegenExpr env (TcoExpr mempty (Var qual))
   CtorSaturated (Qualified qual _) ct ty tag fields ->
     codegenCtor env (fromMaybe currentModule qual) ct ty tag (codegenExpr env <<< snd <$> fields)
   PrimOp op ->

--- a/backend-es/test/snapshots-out/Snapshot.CaseLeafTco.js
+++ b/backend-es/test/snapshots-out/Snapshot.CaseLeafTco.js
@@ -1,44 +1,36 @@
-import * as $runtime from "../runtime.js";
-import * as Data$dArray from "../Data.Array/index.js";
 const test1 = test1$a0$copy => test1$a1$copy => {
   let test1$a0 = test1$a0$copy, test1$a1 = test1$a1$copy, test1$c = true, test1$r;
   while (test1$c) {
     const b = test1$a0, arr = test1$a1;
-    const v = Data$dArray.last(arr);
-    if (0 < arr.length) {
-      if (v.tag === "Just") {
-        if (v._1 === 2 && arr[0] === 1) {
+    const $0 = arr.length - 1 | 0;
+    if ($0 >= 0 && $0 < arr.length) {
+      if (0 < arr.length) {
+        if (arr[$0] === 2 && arr[0] === 1) {
           test1$c = false;
           test1$r = arr;
           continue;
         }
+        const $1 = arr[$0];
         if (b) {
           test1$c = false;
           test1$r = [];
           continue;
         }
         test1$a0 = b;
-        test1$a1 = [v._1, arr[0], 3, v._1, 5, 6, 7, 8, 9, 10, arr[0], 12, 13, 14, 15, 16, 17, ...arr];
+        test1$a1 = [$1, arr[0], 3, $1, 5, 6, 7, 8, 9, 10, arr[0], 12, 13, 14, 15, 16, 17, ...arr];
         continue;
       }
-      if (v.tag === "Nothing") {
-        test1$c = false;
-        test1$r = [...arr, arr[0]];
-        continue;
-      }
-      $runtime.fail();
-    }
-    if (v.tag === "Just") {
       test1$c = false;
-      test1$r = [...arr, v._1];
+      test1$r = [...arr, arr[$0]];
       continue;
     }
-    if (v.tag === "Nothing") {
+    if (0 < arr.length) {
       test1$c = false;
-      test1$r = arr;
+      test1$r = [...arr, arr[0]];
       continue;
     }
-    $runtime.fail();
+    test1$c = false;
+    test1$r = arr;
   }
   return test1$r;
 };

--- a/backend-es/test/snapshots-out/Snapshot.Fusion01.js
+++ b/backend-es/test/snapshots-out/Snapshot.Fusion01.js
@@ -1,12 +1,17 @@
 // @inline export overArray arity=1
 import * as $runtime from "../runtime.js";
 import * as Data$dArray from "../Data.Array/index.js";
-import * as Data$dList from "../Data.List/index.js";
 import * as Data$dList$dTypes from "../Data.List.Types/index.js";
+import * as Data$dMaybe from "../Data.Maybe/index.js";
 import * as Data$dShow from "../Data.Show/index.js";
 import * as Data$dString$dCodeUnits from "../Data.String.CodeUnits/index.js";
+import * as Data$dTuple from "../Data.Tuple/index.js";
 import * as Data$dUnfoldable from "../Data.Unfoldable/index.js";
-const toUnfoldable = /* #__PURE__ */ Data$dList.toUnfoldable(Data$dUnfoldable.unfoldableArray);
+const toUnfoldable = /* #__PURE__ */ (() => Data$dUnfoldable.unfoldableArray.unfoldr(xs => {
+  if (xs.tag === "Nil") { return Data$dMaybe.Nothing; }
+  if (xs.tag === "Cons") { return Data$dMaybe.$Maybe("Just", Data$dTuple.$Tuple(xs._1, xs._2)); }
+  $runtime.fail();
+}))();
 const test = x => Data$dArray.reverse(toUnfoldable((() => {
   const loop = loop$a0$copy => loop$a1$copy => {
     let loop$a0 = loop$a0$copy, loop$a1 = loop$a1$copy, loop$c = true, loop$r;

--- a/backend-es/test/snapshots-out/Snapshot.Fusion02.js
+++ b/backend-es/test/snapshots-out/Snapshot.Fusion02.js
@@ -6,12 +6,17 @@
 // @inline export overArray arity=1
 import * as $runtime from "../runtime.js";
 import * as Data$dArray from "../Data.Array/index.js";
-import * as Data$dList from "../Data.List/index.js";
 import * as Data$dList$dTypes from "../Data.List.Types/index.js";
+import * as Data$dMaybe from "../Data.Maybe/index.js";
 import * as Data$dShow from "../Data.Show/index.js";
 import * as Data$dString$dCodeUnits from "../Data.String.CodeUnits/index.js";
+import * as Data$dTuple from "../Data.Tuple/index.js";
 import * as Data$dUnfoldable from "../Data.Unfoldable/index.js";
-const toUnfoldable = /* #__PURE__ */ Data$dList.toUnfoldable(Data$dUnfoldable.unfoldableArray);
+const toUnfoldable = /* #__PURE__ */ (() => Data$dUnfoldable.unfoldableArray.unfoldr(xs => {
+  if (xs.tag === "Nil") { return Data$dMaybe.Nothing; }
+  if (xs.tag === "Cons") { return Data$dMaybe.$Maybe("Just", Data$dTuple.$Tuple(xs._1, xs._2)); }
+  $runtime.fail();
+}))();
 const test = x => {
   const loop = loop$a0$copy => loop$a1$copy => {
     let loop$a0 = loop$a0$copy, loop$a1 = loop$a1$copy, loop$c = true, loop$r;

--- a/src/PureScript/Backend/Optimizer/Semantics.purs
+++ b/src/PureScript/Backend/Optimizer/Semantics.purs
@@ -1235,8 +1235,6 @@ quote = go
       build ctx $ Var qual
     NeutStop qual ->
       buildStop ctx qual
-    NeutData qual _ _ _ [] ->
-      build ctx $ Var qual
     NeutData qual ct ty tag values ->
       build ctx $ CtorSaturated qual ct ty tag (map (quote ctx) <$> values)
     NeutCtorDef _ ct ty tag fields ->


### PR DESCRIPTION
This is useful for other backends where constructing data is cheap and cross-module references are expensive (like Erlang, where top-level declarations need to be functions). It would be difficult to reconstruct what `Var` reference is really a nullary ctor during codegen, so it is better to keep the constructors and let backend-es optimize the nullary case to its liking.

There's tiny differences in optimizations in the snapshots:
- `CaseLeafTco` looks like it inlined `last`, which looks like an improvement to me (no more intermediate `Maybe` result)
- `Fusion01`/`Fusion02` inlined `toUnfoldable` a bit