### PR TITLE
Add hook for custom analysis

### DIFF
--- a/backend-es/src/Main.purs
+++ b/backend-es/src/Main.purs
@@ -250,6 +250,7 @@ main cliRoot =
   buildCmd args = liftEffect makeBuildState >>= \state -> basicBuildMain
     { resolveCoreFnDirectory: pure args.coreFnDir
     , resolveExternalDirectives: map (fromMaybe Map.empty) $ traverse externalDirectivesFromFile args.directivesFile
+    , analyzeCustom: \_ _ -> Nothing
     , foreignSemantics: Map.union coreForeignSemantics esForeignSemantics
     , onCodegenBefore: do
         liftEffect $ flip Ref.write state.codegenStartTime <<< Just =<< now

--- a/backend-es/test/Main.purs
+++ b/backend-es/test/Main.purs
@@ -120,6 +120,7 @@ runSnapshotTests { accept, filter, traceIdents } = do
       stepsRef <- liftEffect $ Ref.new []
       coreFnModules # buildModules
         { directives
+        , analyzeCustom: \_ _ -> Nothing
         , foreignSemantics: Map.union coreForeignSemantics esForeignSemantics
         , onCodegenModule: \build (Module { name: ModuleName name, path }) backendMod optimizationSteps -> do
             let


### PR DESCRIPTION
This adds an `analyzeCustom` build hook so backends can potentially analyze some expressions in a different way.