### PR TITLE
Add inlining directives for data types

### DIFF
--- a/backend-es/test/snapshots-out/Snapshot.KnownConstructors07.js
+++ b/backend-es/test/snapshots-out/Snapshot.KnownConstructors07.js
@@ -1,0 +1,5 @@
+const test = f => y => {
+  const z = f(y);
+  return {bar: z - 2 | 0, foo: z + 1 | 0};
+};
+export {test};

--- a/backend-es/test/snapshots-out/Snapshot.KnownConstructors08.js
+++ b/backend-es/test/snapshots-out/Snapshot.KnownConstructors08.js
@@ -1,0 +1,1016 @@
+// @inline Data.Generic.Rep.Sum always
+// @inline Data.Show.Generic.genericShowConstructor arity=2
+// @inline export genericTest.from arity=1
+import * as $runtime from "../runtime.js";
+import * as Data$dGeneric$dRep from "../Data.Generic.Rep/index.js";
+const $Test = tag => tag;
+const A = /* #__PURE__ */ $Test("A");
+const B = /* #__PURE__ */ $Test("B");
+const C = /* #__PURE__ */ $Test("C");
+const D = /* #__PURE__ */ $Test("D");
+const E = /* #__PURE__ */ $Test("E");
+const F = /* #__PURE__ */ $Test("F");
+const G = /* #__PURE__ */ $Test("G");
+const H = /* #__PURE__ */ $Test("H");
+const I = /* #__PURE__ */ $Test("I");
+const J = /* #__PURE__ */ $Test("J");
+const K = /* #__PURE__ */ $Test("K");
+const L = /* #__PURE__ */ $Test("L");
+const M = /* #__PURE__ */ $Test("M");
+const N = /* #__PURE__ */ $Test("N");
+const O = /* #__PURE__ */ $Test("O");
+const P = /* #__PURE__ */ $Test("P");
+const Q = /* #__PURE__ */ $Test("Q");
+const R = /* #__PURE__ */ $Test("R");
+const S = /* #__PURE__ */ $Test("S");
+const T = /* #__PURE__ */ $Test("T");
+const U = /* #__PURE__ */ $Test("U");
+const V = /* #__PURE__ */ $Test("V");
+const W = /* #__PURE__ */ $Test("W");
+const X = /* #__PURE__ */ $Test("X");
+const Y = /* #__PURE__ */ $Test("Y");
+const Z = /* #__PURE__ */ $Test("Z");
+const genericTest = {
+  to: x => {
+    if (x.tag === "Inl") { return A; }
+    if (x.tag === "Inr") {
+      if (x._1.tag === "Inl") { return B; }
+      if (x._1.tag === "Inr") {
+        if (x._1._1.tag === "Inl") { return C; }
+        if (x._1._1.tag === "Inr") {
+          if (x._1._1._1.tag === "Inl") { return D; }
+          if (x._1._1._1.tag === "Inr") {
+            if (x._1._1._1._1.tag === "Inl") { return E; }
+            if (x._1._1._1._1.tag === "Inr") {
+              if (x._1._1._1._1._1.tag === "Inl") { return F; }
+              if (x._1._1._1._1._1.tag === "Inr") {
+                if (x._1._1._1._1._1._1.tag === "Inl") { return G; }
+                if (x._1._1._1._1._1._1.tag === "Inr") {
+                  if (x._1._1._1._1._1._1._1.tag === "Inl") { return H; }
+                  if (x._1._1._1._1._1._1._1.tag === "Inr") {
+                    if (x._1._1._1._1._1._1._1._1.tag === "Inl") { return I; }
+                    if (x._1._1._1._1._1._1._1._1.tag === "Inr") {
+                      if (x._1._1._1._1._1._1._1._1._1.tag === "Inl") { return J; }
+                      if (x._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                        if (x._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return K; }
+                        if (x._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                          if (x._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return L; }
+                          if (x._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                            if (x._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return M; }
+                            if (x._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                              if (x._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return N; }
+                              if (x._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return O; }
+                                if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                  if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return P; }
+                                  if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                    if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return Q; }
+                                    if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                      if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return R; }
+                                      if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                        if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return S; }
+                                        if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                          if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return T; }
+                                          if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                            if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return U; }
+                                            if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                              if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return V; }
+                                              if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                                if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return W; }
+                                                if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                                  if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return X; }
+                                                  if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") {
+                                                    if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inl") { return Y; }
+                                                    if (x._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1._1.tag === "Inr") { return Z; }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    $runtime.fail();
+  },
+  from: x => {
+    if (x === "A") { return Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments); }
+    if (x === "B") { return Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)); }
+    if (x === "C") { return Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments))); }
+    if (x === "D") {
+      return Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments))));
+    }
+    if (x === "E") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments))))
+      );
+    }
+    if (x === "F") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments))))
+        )
+      );
+    }
+    if (x === "G") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments))))
+          )
+        )
+      );
+    }
+    if (x === "H") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments))))
+            )
+          )
+        )
+      );
+    }
+    if (x === "I") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments))))
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "J") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments))))
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "K") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments))))
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "L") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments))))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "M") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "N") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "O") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "P") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "Q") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum(
+                                  "Inr",
+                                  Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "R") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum(
+                                  "Inr",
+                                  Data$dGeneric$dRep.$Sum(
+                                    "Inr",
+                                    Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "S") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum(
+                                  "Inr",
+                                  Data$dGeneric$dRep.$Sum(
+                                    "Inr",
+                                    Data$dGeneric$dRep.$Sum(
+                                      "Inr",
+                                      Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "T") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum(
+                                  "Inr",
+                                  Data$dGeneric$dRep.$Sum(
+                                    "Inr",
+                                    Data$dGeneric$dRep.$Sum(
+                                      "Inr",
+                                      Data$dGeneric$dRep.$Sum(
+                                        "Inr",
+                                        Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "U") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum(
+                                  "Inr",
+                                  Data$dGeneric$dRep.$Sum(
+                                    "Inr",
+                                    Data$dGeneric$dRep.$Sum(
+                                      "Inr",
+                                      Data$dGeneric$dRep.$Sum(
+                                        "Inr",
+                                        Data$dGeneric$dRep.$Sum(
+                                          "Inr",
+                                          Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "V") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum(
+                                  "Inr",
+                                  Data$dGeneric$dRep.$Sum(
+                                    "Inr",
+                                    Data$dGeneric$dRep.$Sum(
+                                      "Inr",
+                                      Data$dGeneric$dRep.$Sum(
+                                        "Inr",
+                                        Data$dGeneric$dRep.$Sum(
+                                          "Inr",
+                                          Data$dGeneric$dRep.$Sum(
+                                            "Inr",
+                                            Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "W") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum(
+                                  "Inr",
+                                  Data$dGeneric$dRep.$Sum(
+                                    "Inr",
+                                    Data$dGeneric$dRep.$Sum(
+                                      "Inr",
+                                      Data$dGeneric$dRep.$Sum(
+                                        "Inr",
+                                        Data$dGeneric$dRep.$Sum(
+                                          "Inr",
+                                          Data$dGeneric$dRep.$Sum(
+                                            "Inr",
+                                            Data$dGeneric$dRep.$Sum(
+                                              "Inr",
+                                              Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "X") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum(
+                                  "Inr",
+                                  Data$dGeneric$dRep.$Sum(
+                                    "Inr",
+                                    Data$dGeneric$dRep.$Sum(
+                                      "Inr",
+                                      Data$dGeneric$dRep.$Sum(
+                                        "Inr",
+                                        Data$dGeneric$dRep.$Sum(
+                                          "Inr",
+                                          Data$dGeneric$dRep.$Sum(
+                                            "Inr",
+                                            Data$dGeneric$dRep.$Sum(
+                                              "Inr",
+                                              Data$dGeneric$dRep.$Sum(
+                                                "Inr",
+                                                Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "Y") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum(
+                                  "Inr",
+                                  Data$dGeneric$dRep.$Sum(
+                                    "Inr",
+                                    Data$dGeneric$dRep.$Sum(
+                                      "Inr",
+                                      Data$dGeneric$dRep.$Sum(
+                                        "Inr",
+                                        Data$dGeneric$dRep.$Sum(
+                                          "Inr",
+                                          Data$dGeneric$dRep.$Sum(
+                                            "Inr",
+                                            Data$dGeneric$dRep.$Sum(
+                                              "Inr",
+                                              Data$dGeneric$dRep.$Sum(
+                                                "Inr",
+                                                Data$dGeneric$dRep.$Sum(
+                                                  "Inr",
+                                                  Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inl", Data$dGeneric$dRep.NoArguments)))
+                                                )
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    if (x === "Z") {
+      return Data$dGeneric$dRep.$Sum(
+        "Inr",
+        Data$dGeneric$dRep.$Sum(
+          "Inr",
+          Data$dGeneric$dRep.$Sum(
+            "Inr",
+            Data$dGeneric$dRep.$Sum(
+              "Inr",
+              Data$dGeneric$dRep.$Sum(
+                "Inr",
+                Data$dGeneric$dRep.$Sum(
+                  "Inr",
+                  Data$dGeneric$dRep.$Sum(
+                    "Inr",
+                    Data$dGeneric$dRep.$Sum(
+                      "Inr",
+                      Data$dGeneric$dRep.$Sum(
+                        "Inr",
+                        Data$dGeneric$dRep.$Sum(
+                          "Inr",
+                          Data$dGeneric$dRep.$Sum(
+                            "Inr",
+                            Data$dGeneric$dRep.$Sum(
+                              "Inr",
+                              Data$dGeneric$dRep.$Sum(
+                                "Inr",
+                                Data$dGeneric$dRep.$Sum(
+                                  "Inr",
+                                  Data$dGeneric$dRep.$Sum(
+                                    "Inr",
+                                    Data$dGeneric$dRep.$Sum(
+                                      "Inr",
+                                      Data$dGeneric$dRep.$Sum(
+                                        "Inr",
+                                        Data$dGeneric$dRep.$Sum(
+                                          "Inr",
+                                          Data$dGeneric$dRep.$Sum(
+                                            "Inr",
+                                            Data$dGeneric$dRep.$Sum(
+                                              "Inr",
+                                              Data$dGeneric$dRep.$Sum(
+                                                "Inr",
+                                                Data$dGeneric$dRep.$Sum(
+                                                  "Inr",
+                                                  Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.$Sum("Inr", Data$dGeneric$dRep.NoArguments)))
+                                                )
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+    $runtime.fail();
+  }
+};
+const showTest = {
+  show: x => {
+    if (x === "A") { return "A"; }
+    if (x === "B") { return "B"; }
+    if (x === "C") { return "C"; }
+    if (x === "D") { return "D"; }
+    if (x === "E") { return "E"; }
+    if (x === "F") { return "F"; }
+    if (x === "G") { return "G"; }
+    if (x === "H") { return "H"; }
+    if (x === "I") { return "I"; }
+    if (x === "J") { return "J"; }
+    if (x === "K") { return "K"; }
+    if (x === "L") { return "L"; }
+    if (x === "M") { return "M"; }
+    if (x === "N") { return "N"; }
+    if (x === "O") { return "O"; }
+    if (x === "P") { return "P"; }
+    if (x === "Q") { return "Q"; }
+    if (x === "R") { return "R"; }
+    if (x === "S") { return "S"; }
+    if (x === "T") { return "T"; }
+    if (x === "U") { return "U"; }
+    if (x === "V") { return "V"; }
+    if (x === "W") { return "W"; }
+    if (x === "X") { return "X"; }
+    if (x === "Y") { return "Y"; }
+    if (x === "Z") { return "Z"; }
+    $runtime.fail();
+  }
+};
+export {$Test, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, genericTest, showTest};

--- a/backend-es/test/snapshots/Snapshot.KnownConstructors07.purs
+++ b/backend-es/test/snapshots/Snapshot.KnownConstructors07.purs
@@ -1,4 +1,4 @@
-module Snapshot.KnownConstructor07 where
+module Snapshot.KnownConstructors07 where
 
 import Prelude
 

--- a/backend-es/test/snapshots/Snapshot.KnownConstructors08.purs
+++ b/backend-es/test/snapshots/Snapshot.KnownConstructors08.purs
@@ -1,0 +1,16 @@
+-- @inline Data.Generic.Rep.Sum always
+-- @inline Data.Show.Generic.genericShowConstructor arity=2
+-- @inline export genericTest.from arity=1
+module Snapshot.KnownConstructors08 where
+
+import Prelude
+
+import Data.Generic.Rep (class Generic)
+import Data.Show.Generic (genericShow)
+
+data Test = A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z
+
+derive instance genericTest :: Generic Test _
+
+instance Show Test where
+  show = genericShow

--- a/src/PureScript/Backend/Optimizer/Analysis.purs
+++ b/src/PureScript/Backend/Optimizer/Analysis.purs
@@ -13,7 +13,7 @@ import Data.Set as Set
 import Data.String.CodeUnits as SCU
 import Data.Traversable (foldMap, foldr)
 import Data.Tuple (Tuple(..), snd)
-import PureScript.Backend.Optimizer.CoreFn (Ident, Literal(..), Qualified)
+import PureScript.Backend.Optimizer.CoreFn (Ident(..), Literal(..), ProperName(..), Qualified)
 import PureScript.Backend.Optimizer.Syntax (class HasSyntax, BackendAccessor(..), BackendOperator(..), BackendOperator1(..), BackendSyntax(..), Level, Pair(..), sndPair, syntaxOf)
 
 data Capture = CaptureNone | CaptureBranch | CaptureClosure
@@ -72,7 +72,7 @@ instance Semigroup Complexity where
 instance Monoid Complexity where
   mempty = Trivial
 
-data ResultTerm = KnownNeutral | Unknown
+data ResultTerm = Known (Maybe (Qualified Ident)) | Unknown
 
 derive instance Eq ResultTerm
 
@@ -80,10 +80,14 @@ instance Semigroup ResultTerm where
   append = case _, _ of
     Unknown, _ -> Unknown
     _, Unknown -> Unknown
-    _, _ -> KnownNeutral
+    a@(Known (Just x)), Known (Just y) | x == y -> a
+    a@(Known (Just _)), Known Nothing -> a
+    Known Nothing, b@(Known (Just _)) -> b
+    _, _ -> mempty
+
 
 instance Monoid ResultTerm where
-  mempty = KnownNeutral
+  mempty = Known Nothing
 
 newtype BackendAnalysis = BackendAnalysis
   { usages :: Map Level Usage
@@ -118,7 +122,7 @@ instance Monoid BackendAnalysis where
     , args: []
     , rewrite: false
     , deps: Set.empty
-    , result: KnownNeutral
+    , result: mempty
     , externs: false
     }
 
@@ -244,12 +248,12 @@ analyze externAnalysis expr = case expr of
       $ bump
       $ analysisOf a
   Abs args _ ->
-    withResult KnownNeutral
+    withResult mempty
       $ complex KnownSize
       $ capture CaptureClosure
       $ foldr (boundArg <<< snd) (analyzeDefault expr) args
   UncurriedAbs args _ ->
-    withResult KnownNeutral
+    withResult mempty
       $ complex KnownSize
       $ capture CaptureClosure
       $ foldr (boundArg <<< snd) (analyzeDefault expr) args
@@ -265,7 +269,7 @@ analyze externAnalysis expr = case expr of
         $ complex NonTrivial
         $ analyzeDefault expr
   UncurriedEffectAbs args _ ->
-    withResult KnownNeutral
+    withResult mempty
       $ complex KnownSize
       $ capture CaptureClosure
       $ foldr (boundArg <<< snd) (analyzeDefault expr) args
@@ -311,8 +315,8 @@ analyze externAnalysis expr = case expr of
       withResult Unknown
         $ complex NonTrivial
         $ analyzeDefault expr
-  CtorSaturated qi _ _ _ cs ->
-    withResult KnownNeutral
+  CtorSaturated qi _ (ProperName tyIdent) _ cs ->
+    withResult (Known (Just (qi $> Ident tyIdent)))
       $ bump
       $ usedDep qi
       $ foldMap (foldMap analysisOf) cs
@@ -387,7 +391,7 @@ analyze externAnalysis expr = case expr of
         analysis
     where
     analysis =
-      withResult KnownNeutral
+      withResult mempty
         $ analyzeDefault expr
 
 analyzeEffectBlock :: forall a. HasAnalysis a => HasSyntax a => (Qualified Ident -> Maybe String -> Maybe BackendAnalysis) -> BackendSyntax a -> BackendAnalysis

--- a/src/PureScript/Backend/Optimizer/Convert.purs
+++ b/src/PureScript/Backend/Optimizer/Convert.purs
@@ -370,6 +370,7 @@ getCtx env = Ctx
           else
             analyze lookupExtern expr
   , effect: false
+  , directives: env.directives
   }
   where
   lookupExtern qual acc = do

--- a/src/PureScript/Backend/Optimizer/Directives.purs
+++ b/src/PureScript/Backend/Optimizer/Directives.purs
@@ -111,6 +111,8 @@ qualified :: Parser (Qualified Ident)
 qualified = expectMap case _ of
   { value: CST.TokLowerName (Just (CST.ModuleName mod)) ident } ->
     Just $ Qualified (Just (ModuleName mod)) (Ident ident)
+  { value: CST.TokUpperName (Just (CST.ModuleName mod)) ident } ->
+    Just $ Qualified (Just (ModuleName mod)) (Ident ident)
   _ ->
     Nothing
 


### PR DESCRIPTION
This is a very basic implementation of #72 which might help with things such as large generics inlining. Adding a directive such as:

```
-- @inline Data.Generic.Rep.Sum always
```

Will make the optimizer extremely eager to distribute a continuation over bindings that evaluate to a known constructor of type `Sum`. Note that the directive is on the data type, not individual constructors.

cc @MonoidMusician Any thoughts on this approach?