### PR TITLE
Move formating functions from Main into Main.Print

### DIFF
--- a/backend-es/src/Main.purs
+++ b/backend-es/src/Main.purs
@@ -3,32 +3,49 @@ module Main where
 import Prelude
 
 import ArgParse.Basic (ArgParser)
+import ArgParse.Basic as ArgParser
 import Control.Plus (empty)
+import Data.Array as Array
 import Data.DateTime.Instant (Instant)
+import Data.DateTime.Instant as Instant
 import Data.Either (Either(..), isRight)
 import Data.Foldable (foldMap, for_, oneOf)
 import Data.Function (on)
 import Data.Map (Map)
+import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Monoid (guard, power)
 import Data.Newtype (over2, unwrap)
 import Data.Ord.Down (Down(..))
 import Data.Posix.Signal (Signal(..))
 import Data.Set (Set)
+import Data.Set as Set
 import Data.String (Pattern(..))
+import Data.String as String
+import Data.String.CodeUnits as SCU
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..), snd, uncurry)
+import Dodo as Dodo
 import Effect (Effect)
 import Effect.Aff (Aff, Milliseconds(..), attempt, effectCanceler, error, launchAff_, makeAff, nonCanceler, throwError)
 import Effect.Class (liftEffect)
+import Effect.Class.Console as Console
 import Effect.Now (now)
 import Effect.Ref (Ref)
+import Effect.Ref as Ref
 import Main.Print (formatMs, printTimings, printTotals)
 import Node.ChildProcess (Exit(..), StdIOBehaviour(..), defaultSpawnOptions)
+import Node.ChildProcess as ChildProcess
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff (writeTextFile)
+import Node.FS.Aff as FS
+import Node.FS.Perms as Perms
+import Node.FS.Stats as Stats
 import Node.FS.Stream (createReadStream, createWriteStream)
 import Node.Path (FilePath)
+import Node.Path as Path
+import Node.Process as Process
+import Node.Stream as Stream
 import PureScript.Backend.Optimizer.Codegen.EcmaScript (codegenModule, esModulePath)
 import PureScript.Backend.Optimizer.Codegen.EcmaScript.Builder (basicBuildMain, externalDirectivesFromFile)
 import PureScript.Backend.Optimizer.Codegen.EcmaScript.Foreign (esForeignSemantics)
@@ -37,27 +54,10 @@ import PureScript.Backend.Optimizer.CoreFn (Ident(..), Module(..), ModuleName(..
 import PureScript.Backend.Optimizer.Semantics.Foreign (coreForeignSemantics)
 import PureScript.Backend.Optimizer.Tracer.Printer (printModuleSteps)
 import PureScript.CST.Lexer (lexToken)
-import PureScript.CST.Types (Token(..))
-import Unsafe.Coerce (unsafeCoerce)
-import ArgParse.Basic as ArgParser
-import Data.Array as Array
-import PureScript.CST.Types as CST
-import Node.ChildProcess as ChildProcess
-import Effect.Class.Console as Console
-import Dodo as Dodo
-import Node.FS.Aff as FS
-import Data.DateTime.Instant as Instant
 import PureScript.CST.Lexer as Lexer
-import Data.Map as Map
-import Node.Path as Path
-import Node.FS.Perms as Perms
-import Node.Process as Process
-import Effect.Ref as Ref
-import Data.String.CodeUnits as SCU
-import Data.Set as Set
-import Node.FS.Stats as Stats
-import Node.Stream as Stream
-import Data.String as String
+import PureScript.CST.Types (Token(..))
+import PureScript.CST.Types as CST
+import Unsafe.Coerce (unsafeCoerce)
 import Version as Version
 
 type BuildArgs =

--- a/backend-es/src/Main/Print.purs
+++ b/backend-es/src/Main/Print.purs
@@ -1,19 +1,17 @@
 module Main.Print where
 
-
 import Prelude
 
+import Data.Array (last, sort)
 import Data.Bifunctor (bimap)
 import Data.Maybe (fromMaybe)
 import Data.Newtype (unwrap)
+import Data.Number.Format (toString)
 import Data.Tuple (Tuple(..), fst, snd)
-import Effect.Aff (Milliseconds(..))
-import PureScript.Backend.Optimizer.CoreFn (ModuleName)
-import Data.Array (last, sort)
 import Dodo as Dodo
 import Dodo.Box as Dodo.Box
-import Data.Number.Format (toString)
-
+import Effect.Aff (Milliseconds(..))
+import PureScript.Backend.Optimizer.CoreFn (ModuleName)
 
 formatMs :: Milliseconds -> String
 formatMs (Milliseconds m) = toString m <> "ms"

--- a/backend-es/src/Main/Print.purs
+++ b/backend-es/src/Main/Print.purs
@@ -1,0 +1,46 @@
+module Main.Print where
+
+
+import Prelude
+
+import Data.Bifunctor (bimap)
+import Data.Maybe (fromMaybe)
+import Data.Newtype (unwrap)
+import Data.Tuple (Tuple(..), fst, snd)
+import Effect.Aff (Milliseconds(..))
+import PureScript.Backend.Optimizer.CoreFn (ModuleName)
+import Data.Array (last, sort)
+import Dodo as Dodo
+import Dodo.Box as Dodo.Box
+import Data.Number.Format (toString)
+
+
+formatMs :: Milliseconds -> String
+formatMs (Milliseconds m) = toString m <> "ms"
+
+printTimings :: Array (Tuple ModuleName Milliseconds) -> String
+printTimings =
+  Dodo.print Dodo.plainText Dodo.twoSpaces
+    <<< Dodo.indent
+    <<< printTable
+    <<< map (bimap (Dodo.text <<< append "* " <<< unwrap) (Dodo.text <<< formatMs))
+
+printTotals :: Array (Tuple String Milliseconds) -> String
+printTotals =
+  Dodo.print Dodo.plainText Dodo.twoSpaces
+    <<< printTable
+    <<< map (bimap Dodo.text (Dodo.text <<< formatMs))
+
+printTable :: forall a. Array (Tuple (Dodo.Doc a) (Dodo.Doc a)) -> Dodo.Doc a
+printTable all = Dodo.Box.toDoc table
+  where
+  toBox = Dodo.print Dodo.Box.docBox Dodo.twoSpaces
+  columns = bimap toBox toBox <$> all
+  col1Width = fromMaybe 0 $ last $ sort $ (_.width <<< Dodo.Box.sizeOf <<< fst) <$> columns
+  col2Width = fromMaybe 0 $ last $ sort $ (_.width <<< Dodo.Box.sizeOf <<< snd) <$> columns
+  table = Dodo.Box.vertical $ printRow <$> columns
+  printRow (Tuple a b) = Dodo.Box.horizontal
+    [ Dodo.Box.resize { height: 1, width: col1Width } a
+    , Dodo.Box.hpadding 3
+    , Dodo.Box.resize { height: 1, width: col2Width } (Dodo.Box.halign Dodo.Box.End b)
+    ]


### PR DESCRIPTION
This reduces the amount of code in Main, and the imports in scope for the formating functions. Reducing the cognitive load.

There is some more code related to formating in Main. However, I wanted to make a small change to see if this is anything the project finds value in, and as such I don't want to burden the reviewers with too much code at the same time.