### PR TITLE
Port prettyPrintStringJS to esEscapeString (parity with purs codegen)

### DIFF
--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Common.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Common.purs
@@ -18,14 +18,16 @@ module PureScript.Backend.Optimizer.Codegen.EcmaScript.Common
 
 import Prelude
 
-import Data.Argonaut as Json
 import Data.Array (fold)
 import Data.Array as Array
 import Data.Enum (fromEnum)
+import Data.Foldable (foldMap)
+import Data.Int as Int
 import Data.Maybe (Maybe(..))
 import Data.Set (Set)
 import Data.Set as Set
 import Data.String as String
+import Data.String.CodeUnits as SCU
 import Data.String.Regex as Regex
 import Data.String.Regex.Flags (global, noFlags, unicode)
 import Data.String.Regex.Unsafe (unsafeRegex)
@@ -247,5 +249,29 @@ esTernary a b c =
         ]
     ]
 
+-- Mirrors `prettyPrintStringJS` in the purescript compiler:
+-- https://github.com/purescript/purescript/blob/master/src/Language/PureScript/PSString.hs#L200-L214
+-- Every code unit > 0xFF is escaped as \uXXXX, every other non-printable
+-- ASCII as \xXX. This catches Unicode noncharacters (U+FFFE, U+FFFF,
+-- U+FDD0..U+FDEF) that Chrome MV3 rejects in extension scripts, and avoids
+-- a JSON round-trip.
 esEscapeString :: String -> String
-esEscapeString = Json.stringify <<< Json.fromString
+esEscapeString s = "\"" <> foldMap encode (SCU.toCharArray s) <> "\""
+  where
+  encode c = case fromEnum c of
+    0x08 -> "\\b"
+    0x09 -> "\\t"
+    0x0A -> "\\n"
+    0x0B -> "\\v"
+    0x0C -> "\\f"
+    0x0D -> "\\r"
+    0x22 -> "\\\""
+    0x5C -> "\\\\"
+    n
+      | n > 0xFF -> "\\u" <> padHex 4 n
+      | n < 0x20 || n > 0x7E -> "\\x" <> padHex 2 n
+      | otherwise -> SCU.singleton c
+  padHex width n = leftPadZero width (Int.toStringAs Int.hexadecimal n)
+  leftPadZero width str
+    | String.length str >= width = str
+    | otherwise = leftPadZero width ("0" <> str)

--- a/backend-es/test-snapshots/snapshots-out/Snapshot.BackendSemantics01.js
+++ b/backend-es/test-snapshots/snapshots-out/Snapshot.BackendSemantics01.js
@@ -1,5 +1,5 @@
-const test4 = "\u0000";
-const test3 = "￿";
+const test4 = "\x00";
+const test3 = "\uffff";
 const test2 = -2147483647;
 const test1 = 2147483646;
 export {test1, test2, test3, test4};

--- a/backend-es/test-snapshots/snapshots-out/Snapshot.StringLiteral01.js
+++ b/backend-es/test-snapshots/snapshots-out/Snapshot.StringLiteral01.js
@@ -1,5 +1,5 @@
 const test4 = "\udc11";
-const test3 = "\u0000";
-const test2 = "\u0012";
+const test3 = "\x00";
+const test2 = "\x12";
 const test1 = "B";
 export {test1, test2, test3, test4};


### PR DESCRIPTION
I built a Chrome MV3 extension and tried to upload it to the Chrome Web Store, but it failed to load with `"file is not UTF-8 encoded"`. Chrome MV3 rejects files containing Unicode noncharacters (U+FFFE, U+FFFF, U+FDD0..U+FDEF), and `top :: Char` from `purescript-strings` (= U+FFFF) gets constant-folded into a raw `"￿"` literal.

Repro: https://github.com/i-am-the-slime/purs-backend-es-noncharacter-repro

I had a look at the compiler and there's a discrepancy: [`prettyPrintStringJS`](https://github.com/purescript/purescript/blob/master/src/Language/PureScript/PSString.hs#L200-L214) escapes every codepoint `> 0xFF` as `\uXXXX`, but `esEscapeString` uses `JSON.stringify`, which only escapes C0 controls + `"` + `\`.

This PR ports `prettyPrintStringJS` to `esEscapeString` — fold over UTF-16 code units with guards, no regex, no JSON round-trip. Two existing snapshots updated where ``/`` become `\x00`/`\x12` (matching purs).
