### PR TITLE
Implement Either return for onPrepareModule

### DIFF
--- a/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Builder.purs
+++ b/backend-es/src/PureScript/Backend/Optimizer/Codegen/EcmaScript/Builder.purs
@@ -113,7 +113,7 @@ basicBuildMain options = do
         , directives: allDirectives
         , foreignSemantics: options.foreignSemantics
         , onCodegenModule: options.onCodegenModule
-        , onPrepareModule: options.onPrepareModule
+        , onPrepareModule: \env mod -> Right <$> options.onPrepareModule env mod
         , traceIdents: options.traceIdents
         }
       options.onCodegenAfter

--- a/backend-es/test/Main.purs
+++ b/backend-es/test/Main.purs
@@ -145,7 +145,7 @@ runSnapshotTests { accept, filter, traceIdents } = do
             let index = show (build.moduleIndex + 1)
             let padding = power " " (SCU.length total - SCU.length index)
             Console.log $ "[" <> padding <> index <> " of " <> total <> "] Building " <> unwrap name
-            pure coreFnMod
+            pure (Right coreFnMod)
         , traceIdents
         }
       allSteps <- liftEffect (Ref.read stepsRef)

--- a/src/PureScript/Backend/Optimizer/Builder.purs
+++ b/src/PureScript/Backend/Optimizer/Builder.purs
@@ -6,6 +6,7 @@ module PureScript.Backend.Optimizer.Builder
 
 import Prelude
 
+import Data.Either (Either(..))
 import Data.FoldableWithIndex (foldrWithIndex)
 import Data.List (List, foldM)
 import Data.List as List
@@ -31,7 +32,7 @@ type BuildOptions m =
   { analyzeCustom :: Ctx -> BackendSyntax BackendExpr -> Maybe BackendAnalysis
   , directives :: InlineDirectiveMap
   , foreignSemantics :: Map (Qualified Ident) ForeignEval
-  , onPrepareModule :: BuildEnv -> Module Ann -> m (Module Ann)
+  , onPrepareModule :: BuildEnv -> Module Ann -> m (Either BackendModule (Module Ann))
   , onCodegenModule :: BuildEnv -> Module Ann -> BackendModule -> OptimizationSteps -> m Unit
   , traceIdents :: Set (Qualified Ident)
   }
@@ -45,25 +46,30 @@ buildModules options coreFnModules =
   moduleCount = List.length coreFnModules
   go { directives, implementations, moduleIndex } coreFnModule = do
     let buildEnv = { implementations, moduleCount, moduleIndex }
-    coreFnModule'@(Module { name }) <- options.onPrepareModule buildEnv coreFnModule
-    let
-      Tuple optimizationSteps backendMod = toBackendModule coreFnModule'
-        { analyzeCustom: options.analyzeCustom
-        , currentModule: name
-        , currentLevel: 0
-        , toLevel: Map.empty
-        , implementations
-        , moduleImplementations: Map.empty
-        , directives
-        , dataTypes: Map.empty
-        , foreignSemantics: options.foreignSemantics
-        , rewriteLimit: 10_000
-        , traceIdents: options.traceIdents
-        , optimizationSteps: []
-        }
-      newImplementations =
-        foldrWithIndex Map.insert implementations backendMod.implementations
-    options.onCodegenModule (buildEnv { implementations = newImplementations }) coreFnModule' backendMod optimizationSteps
+    prepared <- options.onPrepareModule buildEnv coreFnModule
+    Tuple backendMod newImplementations <- case prepared of
+      Left cachedMod -> do
+        let newImplementations = foldrWithIndex Map.insert implementations cachedMod.implementations
+        pure (Tuple cachedMod newImplementations)
+      Right coreFnModule'@(Module { name }) -> do
+        let
+          Tuple optimizationSteps compiledMod = toBackendModule coreFnModule'
+            { analyzeCustom: options.analyzeCustom
+            , currentModule: name
+            , currentLevel: 0
+            , toLevel: Map.empty
+            , implementations
+            , moduleImplementations: Map.empty
+            , directives
+            , dataTypes: Map.empty
+            , foreignSemantics: options.foreignSemantics
+            , rewriteLimit: 10_000
+            , traceIdents: options.traceIdents
+            , optimizationSteps: []
+            }
+          newImplementations = foldrWithIndex Map.insert implementations compiledMod.implementations
+        options.onCodegenModule (buildEnv { implementations = newImplementations }) coreFnModule' compiledMod optimizationSteps
+        pure (Tuple compiledMod newImplementations)
     pure
       { directives: foldrWithIndex Map.insert directives backendMod.directives
       , implementations: newImplementations


### PR DESCRIPTION
Resolves #124 

### Description

As discussed in #124, this PR updates the `onPrepareModule` hook to return an `Either BackendModule (Module Ann)` instead of directly returning `Module Ann`. 

This enables custom backends to support faster compilation:
- Returning `Left cachedBackendMod` skips compilation for that module and merges the provided cached implementations/directives.
- Returning `Right coreFnMod` proceeds with the normal compilation pipeline.

### Changes made
- Updated `BuildOptions.onPrepareModule` signature in `PureScript.Backend.Optimizer.Builder`.
- Refactored `buildModules` to handle the `Left`/`Right` logic cleanly without duplicating state updates.
- Updated the `backend-es` CLI (`basicBuildMain`) and its test suite to wrap their existing `onPrepareModule` results in a `Right`, ensuring no behavior changes for the standard executable.
